### PR TITLE
fix: update marked.min.js sha384 hash in versions.json

### DIFF
--- a/static/js/vendor/versions.json
+++ b/static/js/vendor/versions.json
@@ -4,7 +4,7 @@
     "version": "15.0.12",
     "license": "MIT",
     "url": "https://marked.js.org",
-    "sha384": "sha384-tkjnnf9Tzhv5ZFrDroGvUExw9C3EVFo0RFRkzKR8ZX4b5Psoec4yb1PlD8Jh4j4H"
+    "sha384": "sha384-KwzR5her+zXi/Bzz4PVrBjkrjsBZy9adZtt3jA6Jgj3/hzPihRUV6HqMONpTe7Ll"
   },
   "highlight.min.js": {
     "package": "highlight.js",


### PR DESCRIPTION
## Summary
- Update stale `marked.min.js` sha384 hash in `versions.json` to match the actual file on disk
- Fixes failing vendor integrity CI check

## Test plan
- [x] `tools/verify-vendor.sh` passes
- [x] CI vendor integrity step passes