### PR TITLE
feat: inject build version into HTML footers

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -63,6 +63,10 @@ RUN apt-get update && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
 
+# Inject build version into HTML footers
+ARG BUILD_VERSION=dev
+RUN sed -i "s/__BUILD_VERSION__/${BUILD_VERSION}/g" /app/static/*.html
+
 # Change ownership
 RUN chown -R nullpad:nullpad /app
 

--- a/static/admin.html
+++ b/static/admin.html
@@ -126,6 +126,7 @@
 
   <footer class="site-footer">
     <a href="https://github.com/angeswe/nullpad" target="_blank" rel="noopener">GitHub</a>
+    <span class="build-version">__BUILD_VERSION__</span>
   </footer>
 
   <script src="/js/vendor/argon2.umd.min.js" integrity="sha384-tP0Wy54CKmng7i9EoTlPySD0hBx6Octj0VS6MfwlnUu111MPa+JLm0CCbep6XJ1W"></script>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1043,3 +1043,10 @@ input[type="checkbox"]:checked::after {
 .site-footer a:hover {
   color: #4ade80;
 }
+
+.site-footer .build-version {
+  display: block;
+  margin-top: 0.25rem;
+  color: #444;
+  font-size: 0.65rem;
+}

--- a/static/index.html
+++ b/static/index.html
@@ -90,6 +90,7 @@
 
   <footer class="site-footer">
     <a href="https://github.com/angeswe/nullpad" target="_blank" rel="noopener">GitHub</a>
+    <span class="build-version">__BUILD_VERSION__</span>
   </footer>
 
   <script src="/js/vendor/argon2.umd.min.js" integrity="sha384-tP0Wy54CKmng7i9EoTlPySD0hBx6Octj0VS6MfwlnUu111MPa+JLm0CCbep6XJ1W"></script>

--- a/static/info.html
+++ b/static/info.html
@@ -138,6 +138,7 @@
 
   <footer class="site-footer">
     <a href="https://github.com/angeswe/nullpad" target="_blank" rel="noopener">GitHub</a>
+    <span class="build-version">__BUILD_VERSION__</span>
   </footer>
 </body>
 </html>

--- a/static/invite.html
+++ b/static/invite.html
@@ -85,6 +85,7 @@
 
   <footer class="site-footer">
     <a href="https://github.com/angeswe/nullpad" target="_blank" rel="noopener">GitHub</a>
+    <span class="build-version">__BUILD_VERSION__</span>
   </footer>
 
   <script src="/js/vendor/argon2.umd.min.js" integrity="sha384-tP0Wy54CKmng7i9EoTlPySD0hBx6Octj0VS6MfwlnUu111MPa+JLm0CCbep6XJ1W"></script>

--- a/static/login.html
+++ b/static/login.html
@@ -58,6 +58,7 @@
 
   <footer class="site-footer">
     <a href="https://github.com/angeswe/nullpad" target="_blank" rel="noopener">GitHub</a>
+    <span class="build-version">__BUILD_VERSION__</span>
   </footer>
 
   <script src="/js/vendor/argon2.umd.min.js" integrity="sha384-tP0Wy54CKmng7i9EoTlPySD0hBx6Octj0VS6MfwlnUu111MPa+JLm0CCbep6XJ1W"></script>

--- a/static/trusted.html
+++ b/static/trusted.html
@@ -106,6 +106,7 @@
 
   <footer class="site-footer">
     <a href="https://github.com/angeswe/nullpad" target="_blank" rel="noopener">GitHub</a>
+    <span class="build-version">__BUILD_VERSION__</span>
   </footer>
 
   <script src="/js/vendor/argon2.umd.min.js" integrity="sha384-tP0Wy54CKmng7i9EoTlPySD0hBx6Octj0VS6MfwlnUu111MPa+JLm0CCbep6XJ1W"></script>

--- a/static/view.html
+++ b/static/view.html
@@ -85,6 +85,7 @@
 
   <footer class="site-footer">
     <a href="https://github.com/angeswe/nullpad" target="_blank" rel="noopener">GitHub</a>
+    <span class="build-version">__BUILD_VERSION__</span>
   </footer>
 
   <script src="/js/vendor/marked.min.js" integrity="sha384-KwzR5her+zXi/Bzz4PVrBjkrjsBZy9adZtt3jA6Jgj3/hzPihRUV6HqMONpTe7Ll"></script>


### PR DESCRIPTION
## Summary
- Add `__BUILD_VERSION__` placeholder span in all 7 HTML page footers
- Style it smaller/dimmer (`0.65rem`, `#444`) below the GitHub link
- Dockerfile.prod accepts `BUILD_VERSION` ARG and sed-replaces it after SRI regeneration
- `.build/build.sh` passes `--build-arg BUILD_VERSION=$timestamp` (local, gitignored)

## Verification
- `grep __BUILD_VERSION__ static/*.html` confirms placeholder in all 7 files
- Local dev shows raw `__BUILD_VERSION__` text (harmless)
- Docker build replaces it with the build timestamp (e.g. `20260207-143022`)

## Test plan
- [x] Verify placeholder visible in all HTML footers locally
- [ ] Build Docker image and confirm timestamp replaces placeholder
- [ ] Confirm styling matches theme (dark, small text below GitHub link)