### PR TITLE
fix: CI audit job permissions and ignore unmaintained warning

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,9 @@
+# Cargo audit configuration
+# See: https://rustsec.org/
+
+[advisories]
+# Ignore RUSTSEC-2025-0134: rustls-pemfile unmaintained
+# - This is informational only (not a vulnerability)
+# - Dependency comes from testcontainers (dev-only)
+# - Will be resolved when bollard updates
+ignore = ["RUSTSEC-2025-0134"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      checks: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0


### PR DESCRIPTION
## Summary
- Add `checks:write` permission to audit job so `rustsec/audit-check` can create check runs (fixes "Resource not accessible by integration" error)
- Add `.cargo/audit.toml` to ignore RUSTSEC-2025-0134 (rustls-pemfile unmaintained) - informational only, from testcontainers dev dependency

## Test plan
- [x] CI pipeline passes (audit job should complete without permission errors)