### PR TITLE
fix: add paste storage volume for read-only container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,8 +49,11 @@ RUN apt-get update && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
 
+# Create paste storage directory
+RUN mkdir -p /data/pastes
+
 # Change ownership
-RUN chown -R nullpad:nullpad /app
+RUN chown -R nullpad:nullpad /app /data
 
 # Switch to non-root user
 USER nullpad

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       - ALL
     volumes:
       - ./static:/app/static:ro
+      - paste-data:/data/pastes
     tmpfs:
       - /tmp
 
@@ -71,3 +72,4 @@ networks:
 
 volumes:
   redis-data:
+  paste-data:


### PR DESCRIPTION
## Summary

Container runs with `read_only: true` but paste storage needs a writable directory. 

Changes:
- Add `paste-data` volume mount in docker-compose.yml
- Create `/data/pastes` directory in Dockerfile with proper ownership

## Test plan

- [x] Docker compose starts successfully
- [x] Health check returns OK
- [x] Paste creation works (writes to volume)