### PR TITLE
fix: info.html 404 due to file permissions in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,8 +52,8 @@ RUN apt-get update && \
 # Create paste storage directory
 RUN mkdir -p /data/pastes
 
-# Change ownership
-RUN chown -R nullpad:nullpad /app /data
+# Ensure static files are world-readable and change ownership
+RUN chmod -R a+rX /app/static && chown -R nullpad:nullpad /app /data
 
 # Switch to non-root user
 USER nullpad

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -67,8 +67,8 @@ RUN apt-get update && \
 ARG BUILD_VERSION=dev
 RUN sed -i "s/__BUILD_VERSION__/${BUILD_VERSION}/g" /app/static/*.html
 
-# Change ownership
-RUN chown -R nullpad:nullpad /app
+# Ensure static files are world-readable and change ownership
+RUN chmod -R a+rX /app/static && chown -R nullpad:nullpad /app
 
 # Switch to non-root user
 USER nullpad


### PR DESCRIPTION
## Summary
- `info.html` returned 404 in production because it was committed with `0600` (owner-only) permissions — the `nullpad` container user couldn't read it
- Added `chmod -R a+rX /app/static` in both `Dockerfile` and `Dockerfile.prod` as defense in depth, ensuring all static files are world-readable regardless of source permissions
- The pre-commit hook in `.githooks/` already catches this for new commits, but `info.html` predated the hook

## Test plan
- [x] Rebuild image and deploy
- [x] Verify `/info.html` returns 200