### PR TITLE
ci: add Trivy container image scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,3 +98,21 @@ jobs:
       - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+  container-scan:
+    name: Container Scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Build image
+        run: docker build -t nullpad:scan .
+      - name: Trivy vulnerability scan
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # v0.33.1
+        with:
+          image-ref: 'nullpad:scan'
+          format: 'table'
+          exit-code: '1'
+          severity: 'CRITICAL,HIGH'
+          ignore-unfixed: true


### PR DESCRIPTION
## Summary
- Adds a Trivy scan job to CI that builds the Docker image and checks for CRITICAL/HIGH CVEs in OS packages
- Fails the pipeline if exploitable vulnerabilities are found
- Ignores unfixed CVEs (no patch available) to avoid false-positive blocks

## Test plan
- [x] CI runs the new `container-scan` job successfully
- [x] Verify Trivy output appears in the job logs