### PR TITLE
fix: handle non-JSON error responses in view.js

### DIFF
--- a/static/js/view.js
+++ b/static/js/view.js
@@ -121,8 +121,24 @@
       const response = await fetch(`/api/paste/${pasteId}`);
 
       if (!response.ok) {
-        const error = await response.json();
-        throw new Error(error.error || 'Failed to fetch paste');
+        // Try to parse JSON error, fall back to status-based message
+        let errorMessage;
+        try {
+          const error = await response.json();
+          errorMessage = error.error;
+        } catch {
+          // Response wasn't JSON (proxy error, network issue, etc.)
+        }
+        if (!errorMessage) {
+          if (response.status === 404) {
+            errorMessage = 'Paste not found or has expired';
+          } else if (response.status === 429) {
+            errorMessage = 'Too many requests. Please wait.';
+          } else {
+            errorMessage = 'Server error (' + response.status + ')';
+          }
+        }
+        throw new Error(errorMessage);
       }
 
       const data = await response.json();
@@ -135,7 +151,7 @@
 
       return data;
     } catch (err) {
-      throw new Error('Failed to fetch paste: ' + err.message);
+      throw new Error(err.message || 'Failed to fetch paste');
     }
   }
 

--- a/static/view.html
+++ b/static/view.html
@@ -93,6 +93,6 @@
   <script src="/js/vendor/purify.min.js" integrity="sha384-80VlBZnyAwkkqtSfg5NhPyZff6nU4K/qniLBL8Jnm4KDv6jZhLiYtJbhglg/i9ww"></script>
   <script src="/js/vendor/argon2.umd.min.js" integrity="sha384-tP0Wy54CKmng7i9EoTlPySD0hBx6Octj0VS6MfwlnUu111MPa+JLm0CCbep6XJ1W"></script>
   <script src="/js/crypto.js" integrity="sha384-oEqnHJyXXopvMYc57+/X5IicjLUgOGUriUEhqx/3dQOzezlRHR/fDb7kVIJPnio/"></script>
-  <script src="/js/view.js" integrity="sha384-sVNZj0qaFhr/+B91EFN9aOPOIlTH3DYyuohqfpBfPFJW45Klfhg/P8U4aUU+cxDA"></script>
+  <script src="/js/view.js" integrity="sha384-D3J0YHCtM2V6E7ZGFMXFpRONgI7RMVSGJeZVZwVYkgzDWwZZ9N6DQ0fo62Y5RNkQ"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Fixed JSON parse error when viewing expired/deleted pastes
- The `fetchPaste` function now gracefully handles non-JSON error responses (proxy errors, timeouts, malformed responses)
- Falls back to user-friendly status-based messages:
  - 404: "Paste not found or has expired"
  - 429: "Too many requests. Please wait."
  - Other: "Server error (status)"

## Root Cause
When a paste expired, the server returns `{"error": "Paste not found"}` correctly. However, if something else intercepts the request (proxy, CDN, network timeout), the response might not be JSON. The code tried to parse it with `response.json()` without a try-catch, causing "Unexpected token" errors.

## Note on Redis TTLs
Redis automatically deletes keys when their TTL expires - this is native Redis behavior and works correctly. The blob files on disk are cleaned up separately by a background job every 5 minutes. If you're seeing items with TTLs in Redis, they either:
1. Haven't expired yet (TTL > 0)
2. Are "forever" pastes (ttl_secs=0) from trusted/admin users

## Test plan
- [ ] Visit an expired paste link - should show "Paste not found or has expired"
- [ ] Disconnect network and visit paste link - should show graceful error instead of JSON parse error