### PR TITLE
fix: use client paste ID and encrypted metadata to fix AAD mismatch

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -25,6 +25,9 @@ pub enum AppError {
     #[error("Not found: {0}")]
     NotFound(String),
 
+    #[error("Conflict: {0}")]
+    Conflict(String),
+
     #[error("Rate limited")]
     RateLimited {
         /// Seconds until the rate limit window resets (for Retry-After header).
@@ -47,6 +50,7 @@ impl IntoResponse for AppError {
             AppError::Unauthorized(msg) => (StatusCode::UNAUTHORIZED, msg.clone()),
             AppError::Forbidden(msg) => (StatusCode::FORBIDDEN, msg.clone()),
             AppError::NotFound(msg) => (StatusCode::NOT_FOUND, msg.clone()),
+            AppError::Conflict(msg) => (StatusCode::CONFLICT, msg.clone()),
             AppError::RateLimited { .. } => (
                 StatusCode::TOO_MANY_REQUESTS,
                 "Rate limit exceeded".to_string(),

--- a/src/models.rs
+++ b/src/models.rs
@@ -5,6 +5,10 @@
 
 use serde::{Deserialize, Serialize};
 
+fn default_paste_type() -> String {
+    "text".to_string()
+}
+
 // ============================================================================
 // Paste Models
 // ============================================================================
@@ -12,8 +16,12 @@ use serde::{Deserialize, Serialize};
 /// Metadata for paste creation (sent as JSON in multipart form).
 #[derive(Debug, Deserialize)]
 pub struct PasteMetadata {
-    pub filename: String,
-    pub content_type: String,
+    /// Client-generated paste ID (nanoid, 12 chars). Used as AES-GCM AAD.
+    pub paste_id: String,
+    /// Encrypted filename + content_type blob (base64). Server stores opaquely.
+    pub encrypted_metadata: String,
+    /// Paste type: "text" or "file". Public users restricted to "text".
+    pub paste_type: String,
     /// TTL in seconds. If omitted, uses server config DEFAULT_TTL_SECS.
     pub ttl_secs: Option<u64>,
     #[serde(default)]
@@ -31,8 +39,15 @@ pub struct CreatePasteResponse {
 #[derive(Debug, Serialize)]
 pub struct GetPasteResponse {
     pub encrypted_content: String, // base64
-    pub filename: String,
-    pub content_type: String,
+    /// Encrypted metadata blob (new pastes). Empty for legacy pastes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub encrypted_metadata: Option<String>,
+    /// Legacy plaintext filename (old pastes only).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filename: Option<String>,
+    /// Legacy plaintext content type (old pastes only).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content_type: Option<String>,
     pub burn_after_reading: bool,
     pub created_at: u64,
 }
@@ -42,8 +57,18 @@ pub struct GetPasteResponse {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StoredPasteMeta {
     pub id: String,
-    pub filename: String,
-    pub content_type: String,
+    /// Encrypted metadata blob (new pastes).
+    #[serde(default)]
+    pub encrypted_metadata: String,
+    /// Paste type: "text" or "file". Defaults to "text" for legacy pastes.
+    #[serde(default = "default_paste_type")]
+    pub paste_type: String,
+    /// Legacy plaintext filename (old pastes only).
+    #[serde(default)]
+    pub filename: Option<String>,
+    /// Legacy plaintext content type (old pastes only).
+    #[serde(default)]
+    pub content_type: Option<String>,
     pub burn_after_reading: bool,
     pub created_at: u64,
     pub owner_id: Option<String>,
@@ -61,8 +86,7 @@ pub struct StoredPaste {
 #[derive(Debug, Serialize)]
 pub struct PasteInfo {
     pub id: String,
-    pub filename: String,
-    pub content_type: String,
+    pub paste_type: String,
     pub created_at: u64,
     pub ttl: u64,
     pub burn_after_reading: bool,

--- a/src/routes/paste.rs
+++ b/src/routes/paste.rs
@@ -15,41 +15,14 @@ use axum::{
 use base64::{engine::general_purpose, Engine as _};
 use std::net::SocketAddr;
 
-/// Basic MIME type validation: must match `type/subtype` pattern with optional parameters.
-/// Accepts formats like `text/plain`, `application/octet-stream`, `text/html; charset=utf-8`.
-fn is_valid_mime(s: &str) -> bool {
-    // Split off parameters (e.g., "; charset=utf-8")
-    let base = match s.split_once(';') {
-        Some((base, _)) => base.trim(),
-        None => s.trim(),
-    };
-
-    // Must contain exactly one slash separating type and subtype
-    let (typ, subtype) = match base.split_once('/') {
-        Some(parts) => parts,
-        None => return false,
-    };
-
-    // Both type and subtype must be non-empty and contain only valid token chars
-    // RFC 7231: token = 1*tchar, tchar = "!" / "#" / "$" / "%" / "&" / "'" / "*"
-    //           / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA
-    fn is_token(s: &str) -> bool {
-        !s.is_empty()
-            && s.bytes()
-                .all(|b| b.is_ascii_alphanumeric() || b"!#$%&'*+-.^_`|~".contains(&b))
-    }
-
-    is_token(typ) && is_token(subtype)
-}
-
 /// POST /api/paste — Create paste
 ///
 /// Accepts multipart form with:
-/// - "metadata" field: JSON PasteMetadata
+/// - "metadata" field: JSON PasteMetadata (paste_id, encrypted_metadata, paste_type, ttl_secs, burn_after_reading)
 /// - "file" field: encrypted bytes
 ///
-/// Public users: only .md/.txt extensions allowed
-/// Authenticated users: any file type allowed
+/// Public users: text paste type only
+/// Authenticated users: text and file paste types
 pub async fn create_paste(
     State(state): State<AppState>,
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
@@ -130,38 +103,35 @@ pub async fn create_paste(
     let encrypted_content =
         encrypted_content.ok_or_else(|| AppError::BadRequest("Missing file".to_string()))?;
 
-    // Validate filename: max 255 chars, no null bytes, no path separators
-    if metadata.filename.len() > 255 {
+    // Validate client-generated paste ID
+    super::validate_id(&metadata.paste_id, "paste ID", 12)?;
+
+    // Validate encrypted_metadata: non-empty, valid base64, max 4096 bytes decoded
+    if metadata.encrypted_metadata.is_empty() {
         return Err(AppError::BadRequest(
-            "Filename too long (max 255 characters)".to_string(),
+            "Missing encrypted_metadata".to_string(),
         ));
     }
-    if metadata.filename.contains('\0')
-        || metadata.filename.contains('/')
-        || metadata.filename.contains('\\')
-    {
+    let decoded_meta = general_purpose::STANDARD
+        .decode(&metadata.encrypted_metadata)
+        .map_err(|_| AppError::BadRequest("Invalid encrypted_metadata encoding".to_string()))?;
+    if decoded_meta.len() > 4096 {
         return Err(AppError::BadRequest(
-            "Filename contains invalid characters".to_string(),
+            "encrypted_metadata too large (max 4096 bytes)".to_string(),
         ));
-    }
-    if metadata.filename.is_empty() {
-        return Err(AppError::BadRequest("Filename cannot be empty".to_string()));
     }
 
-    // Validate content_type: max 127 chars, ASCII only, no null bytes, valid MIME format
-    if metadata.content_type.len() > 127 {
+    // Validate paste_type: must be "text" or "file"
+    if metadata.paste_type != "text" && metadata.paste_type != "file" {
         return Err(AppError::BadRequest(
-            "Content type too long (max 127 characters)".to_string(),
+            "paste_type must be \"text\" or \"file\"".to_string(),
         ));
     }
-    if !metadata.content_type.is_ascii() || metadata.content_type.contains('\0') {
-        return Err(AppError::BadRequest(
-            "Content type contains invalid characters".to_string(),
-        ));
-    }
-    if !is_valid_mime(&metadata.content_type) {
-        return Err(AppError::BadRequest(
-            "Invalid content type format".to_string(),
+
+    // Public users can only create text pastes
+    if auth_session.is_none() && metadata.paste_type == "file" {
+        return Err(AppError::Forbidden(
+            "File uploads require authentication".to_string(),
         ));
     }
 
@@ -172,25 +142,6 @@ pub async fn create_paste(
             encrypted_content.len(),
             state.config.max_upload_bytes
         )));
-    }
-
-    // Extract extension from filename (use rsplit_once to get only the final extension)
-    let extension = metadata
-        .filename
-        .rsplit_once('.')
-        .map(|(_, ext)| ext.to_lowercase());
-
-    // If no auth session, enforce public extension restrictions
-    if auth_session.is_none() {
-        match &extension {
-            Some(ext) if state.config.public_allowed_extensions.contains(ext) => {}
-            _ => {
-                return Err(AppError::Forbidden(format!(
-                    "File type not allowed for public uploads. Allowed: {}",
-                    state.config.public_allowed_extensions.join(", ")
-                )));
-            }
-        }
     }
 
     // Use config default if client omitted ttl_secs.
@@ -227,15 +178,17 @@ pub async fn create_paste(
         }
     }
 
-    // Generate paste ID
-    let paste_id = nanoid::nanoid!(12);
+    // Use client-generated paste ID (validated above)
+    let paste_id = metadata.paste_id;
 
     // Create stored paste (metadata + content)
     let paste = StoredPaste {
         meta: StoredPasteMeta {
             id: paste_id.clone(),
-            filename: metadata.filename,
-            content_type: metadata.content_type,
+            encrypted_metadata: metadata.encrypted_metadata,
+            paste_type: metadata.paste_type,
+            filename: None,
+            content_type: None,
             burn_after_reading: metadata.burn_after_reading,
             created_at: crate::util::now_secs(),
             owner_id: auth_session.as_ref().map(|s| s.user_id.clone()),
@@ -243,7 +196,7 @@ pub async fn create_paste(
         encrypted_content,
     };
 
-    // Store paste (metadata to Redis, content to disk)
+    // Store paste (metadata to Redis via SETNX, then content to disk)
     storage::paste::store_paste(
         &mut con,
         &state.config.paste_storage_path,
@@ -251,7 +204,16 @@ pub async fn create_paste(
         ttl_secs,
         state.config.max_ttl_secs,
     )
-    .await?;
+    .await
+    .map_err(|e| {
+        // store_paste returns UnexpectedReturnType with detail "conflict"
+        // when the paste ID already exists (SETNX failed).
+        if e.kind() == redis::ErrorKind::UnexpectedReturnType && e.detail() == Some("conflict") {
+            AppError::Conflict("Paste ID already exists".to_string())
+        } else {
+            AppError::from(e)
+        }
+    })?;
 
     // On first upload, atomically update user TTL from idle to active.
     // Uses SCARD + TTL comparison to avoid race conditions between concurrent uploads.
@@ -323,8 +285,16 @@ pub async fn get_paste(
     .await?
     .ok_or_else(|| AppError::NotFound("Paste not found".to_string()))?;
 
+    // Return encrypted_metadata for new pastes, legacy fields for old pastes
+    let encrypted_metadata = if paste.meta.encrypted_metadata.is_empty() {
+        None
+    } else {
+        Some(paste.meta.encrypted_metadata)
+    };
+
     Ok(Json(GetPasteResponse {
         encrypted_content: general_purpose::STANDARD.encode(&paste.encrypted_content),
+        encrypted_metadata,
         filename: paste.meta.filename,
         content_type: paste.meta.content_type,
         burn_after_reading: paste.meta.burn_after_reading,

--- a/src/storage/blob.rs
+++ b/src/storage/blob.rs
@@ -139,8 +139,25 @@ pub async fn write_blob(storage_path: &Path, id: &str, content: &[u8]) -> Result
         .strip_prefix(&canonical_storage)
         .map_err(|_| BlobError::InvalidId("Path escapes storage directory".to_string()))?;
 
-    // Write atomically: temp file -> sync -> rename
-    let mut file = fs::File::create(&temp_path).await?;
+    // Write atomically: temp file (exclusive create) -> sync -> rename.
+    // If a stale temp file exists from a previous crash, remove it first.
+    let open_result = fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&temp_path)
+        .await;
+    let mut file = match open_result {
+        Ok(f) => f,
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+            fs::remove_file(&temp_path).await?;
+            fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&temp_path)
+                .await?
+        }
+        Err(e) => return Err(e.into()),
+    };
     file.write_all(content).await?;
     file.sync_all().await?;
     fs::rename(&temp_path, &blob_path).await?;

--- a/src/storage/paste.rs
+++ b/src/storage/paste.rs
@@ -12,7 +12,11 @@ use crate::storage::blob;
 use redis::AsyncCommands;
 use std::path::Path;
 
-/// Store a paste: content on disk, metadata in Redis.
+/// Store a paste: claim ID in Redis first (SETNX), then write content to disk.
+///
+/// Uses SET NX (set-if-not-exists) to atomically claim the paste ID, preventing
+/// overwrites of existing pastes. If the ID already exists, returns an error
+/// that maps to 409 Conflict.
 ///
 /// If the paste has an owner_id, also add the paste ID to the user's paste set.
 /// `max_ttl_secs` is used for the user_pastes SET expiry (from config.max_ttl_secs).
@@ -26,17 +30,6 @@ pub async fn store_paste<C>(
 where
     C: AsyncCommands,
 {
-    // Write content to disk first (so we don't have orphan metadata)
-    blob::write_blob(storage_path, &paste.meta.id, &paste.encrypted_content)
-        .await
-        .map_err(|e| {
-            redis::RedisError::from((
-                redis::ErrorKind::UnexpectedReturnType,
-                "Blob write failed",
-                e.to_string(),
-            ))
-        })?;
-
     let key = format!("paste:{}", paste.meta.id);
     let json = serde_json::to_string(&paste.meta).map_err(|e| {
         redis::RedisError::from((
@@ -46,14 +39,48 @@ where
         ))
     })?;
 
-    // Store metadata: ttl_secs=0 means forever (no expiration)
-    if ttl_secs == 0 {
-        con.set::<_, _, ()>(&key, json).await?;
-    } else {
-        con.set_ex::<_, _, ()>(&key, json, ttl_secs).await?;
+    // Step 1: Atomically claim the paste ID with SET NX (set-if-not-exists).
+    // This prevents overwriting existing pastes when clients control the ID.
+    // Redis SET NX returns "OK" on success or nil when key exists.
+    let mut cmd = redis::cmd("SET");
+    cmd.arg(&key).arg(&json);
+    if ttl_secs > 0 {
+        cmd.arg("EX").arg(ttl_secs);
+    }
+    cmd.arg("NX");
+
+    // Redis SET NX returns "OK" (Some) on success, nil (None) when key exists.
+    // Using Option<String> correctly maps nil to None without type errors.
+    // Real Redis errors (connection, auth, OOM) propagate via `?`.
+    let result: Option<String> = cmd.query_async(con).await?;
+    let claimed = result.is_some();
+
+    if !claimed {
+        return Err(redis::RedisError::from((
+            redis::ErrorKind::UnexpectedReturnType,
+            "Paste ID already exists",
+            "conflict".to_string(),
+        )));
     }
 
-    // If paste has an owner, add to user's paste set
+    // Step 2: Write content to disk (only after Redis confirms the ID is ours).
+    if let Err(e) = blob::write_blob(storage_path, &paste.meta.id, &paste.encrypted_content).await {
+        // Cleanup: delete Redis key if blob write fails
+        if let Err(cleanup_err) = con.del::<_, ()>(&key).await {
+            tracing::error!(
+                paste_id = %paste.meta.id,
+                error = %cleanup_err,
+                "Failed to clean up Redis key after blob write failure"
+            );
+        }
+        return Err(redis::RedisError::from((
+            redis::ErrorKind::UnexpectedReturnType,
+            "Blob write failed",
+            e.to_string(),
+        )));
+    }
+
+    // Step 3: If paste has an owner, add to user's paste set
     if let Some(ref owner_id) = paste.meta.owner_id {
         let user_pastes_key = format!("user_pastes:{}", owner_id);
         con.sadd::<_, _, ()>(&user_pastes_key, &paste.meta.id)

--- a/static/index.html
+++ b/static/index.html
@@ -93,6 +93,6 @@
 
   <script src="/js/vendor/argon2.umd.min.js" integrity="sha384-tP0Wy54CKmng7i9EoTlPySD0hBx6Octj0VS6MfwlnUu111MPa+JLm0CCbep6XJ1W"></script>
   <script src="/js/crypto.js" integrity="sha384-L4s53PBPpJg1PnQa/gidQSD96ByUFqquNwXFrtbc1g55V/9Al/Dv7Yg6/O9c6VQd"></script>
-  <script src="/js/create.js" integrity="sha384-aTvqvmLowJenPoi5I67MScI2V6OIdUzqrSpY2HeNMnSyGjjb+2WBa9FALRgkA9vD"></script>
+  <script src="/js/create.js" integrity="sha384-emd9Ek+HuyZA1nHUGtXyBFsI6nr0lQKD7Q00lNeCiN6piUGvb0W0D113m07UH/tk"></script>
 </body>
 </html>

--- a/static/js/create.js
+++ b/static/js/create.js
@@ -184,6 +184,7 @@
       const metadata = JSON.stringify({
         paste_id: clientPasteId,
         encrypted_metadata: encryptedMetadata,
+        paste_type: currentFile ? 'file' : 'text',
         ttl_secs: parseInt(ttlSelect.value, 10),
         burn_after_reading: burnCheckbox.checked
       });

--- a/static/trusted.html
+++ b/static/trusted.html
@@ -110,7 +110,7 @@
   <script src="/js/vendor/argon2.umd.min.js" integrity="sha384-tP0Wy54CKmng7i9EoTlPySD0hBx6Octj0VS6MfwlnUu111MPa+JLm0CCbep6XJ1W"></script>
   <script src="/js/crypto.js" integrity="sha384-L4s53PBPpJg1PnQa/gidQSD96ByUFqquNwXFrtbc1g55V/9Al/Dv7Yg6/O9c6VQd"></script>
   <script src="/js/auth.js" integrity="sha384-OC5YYRrtpzvzXVbk9Jlns+kEWgxFrD6cYA6wPV5RkuYOB9DhN51beYOXISeTD/QZ"></script>
-  <script src="/js/create.js" integrity="sha384-aTvqvmLowJenPoi5I67MScI2V6OIdUzqrSpY2HeNMnSyGjjb+2WBa9FALRgkA9vD"></script>
+  <script src="/js/create.js" integrity="sha384-emd9Ek+HuyZA1nHUGtXyBFsI6nr0lQKD7Q00lNeCiN6piUGvb0W0D113m07UH/tk"></script>
   <script src="/js/trusted.js" integrity="sha384-wD4K/p/w1yS+yG9H9WP1Co0/TJmy2sUwC5iW6zEYPmGvptqUENoVprXBdHHz+3Mr"></script>
 </body>
 </html>

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -170,18 +170,25 @@ async fn admin_login(
 }
 
 /// Helper: create a paste via multipart.
+///
+/// `paste_type` should be "text" or "file".
 async fn create_paste(
     client: &reqwest::Client,
     base_url: &str,
-    filename: &str,
+    paste_type: &str,
     content: &[u8],
     burn: bool,
     ttl: u64,
     token: Option<&str>,
 ) -> reqwest::Response {
+    let paste_id = nanoid::nanoid!(12);
+    // Use a dummy base64 blob as encrypted_metadata (server stores opaquely)
+    let encrypted_metadata = general_purpose::STANDARD.encode(b"encrypted-file-metadata");
+
     let metadata = serde_json::json!({
-        "filename": filename,
-        "content_type": "application/octet-stream",
+        "paste_id": paste_id,
+        "encrypted_metadata": encrypted_metadata,
+        "paste_type": paste_type,
         "ttl_secs": ttl,
         "burn_after_reading": burn
     });
@@ -196,7 +203,7 @@ async fn create_paste(
         .part(
             "file",
             multipart::Part::bytes(content.to_vec())
-                .file_name(filename.to_string())
+                .file_name("encrypted")
                 .mime_str("application/octet-stream")
                 .unwrap(),
         );
@@ -225,7 +232,7 @@ async fn test_create_and_get_paste() {
     let resp = create_paste(
         &client,
         &base_url,
-        "test.md",
+        "text",
         b"encrypted data",
         false,
         3600,
@@ -247,7 +254,7 @@ async fn test_create_and_get_paste() {
     assert_eq!(resp.status(), 200);
 
     let body: serde_json::Value = resp.json().await.unwrap();
-    assert_eq!(body["filename"].as_str().unwrap(), "test.md");
+    assert!(body["encrypted_metadata"].as_str().is_some());
     assert!(!body["burn_after_reading"].as_bool().unwrap());
 
     // Decode content
@@ -263,16 +270,7 @@ async fn test_burn_after_reading() {
     let client = reqwest::Client::new();
 
     // Create a burn paste
-    let resp = create_paste(
-        &client,
-        &base_url,
-        "secret.txt",
-        b"burn me",
-        true,
-        3600,
-        None,
-    )
-    .await;
+    let resp = create_paste(&client, &base_url, "text", b"burn me", true, 3600, None).await;
     assert_eq!(resp.status(), 200);
 
     let body: serde_json::Value = resp.json().await.unwrap();
@@ -321,30 +319,83 @@ async fn test_paste_not_found() {
 }
 
 #[tokio::test]
-async fn test_public_extension_restriction() {
+async fn test_public_paste_type_restriction() {
     let (base_url, _con, _admin_key, _admin_alias) = spawn_test_server().await;
     let client = reqwest::Client::new();
 
-    // .exe should be rejected for public uploads
-    let resp = create_paste(
-        &client,
-        &base_url,
-        "malware.exe",
-        b"data",
-        false,
-        3600,
-        None,
-    )
-    .await;
+    // "file" type should be rejected for public uploads
+    let resp = create_paste(&client, &base_url, "file", b"data", false, 3600, None).await;
     assert_eq!(resp.status(), 403);
 
-    // .md should be allowed
-    let resp = create_paste(&client, &base_url, "readme.md", b"data", false, 3600, None).await;
+    // "text" type should be allowed for public uploads
+    let resp = create_paste(&client, &base_url, "text", b"data", false, 3600, None).await;
+    assert_eq!(resp.status(), 200);
+}
+
+#[tokio::test]
+async fn test_duplicate_paste_id_returns_409() {
+    let (base_url, _con, _admin_key, _admin_alias) = spawn_test_server().await;
+    let client = reqwest::Client::new();
+
+    // Use a fixed paste ID for both requests
+    let paste_id = nanoid::nanoid!(12);
+    let encrypted_metadata = general_purpose::STANDARD.encode(b"encrypted-file-metadata");
+
+    let metadata = serde_json::json!({
+        "paste_id": paste_id,
+        "encrypted_metadata": encrypted_metadata,
+        "paste_type": "text",
+        "ttl_secs": 3600,
+        "burn_after_reading": false
+    });
+
+    let form = multipart::Form::new()
+        .part(
+            "metadata",
+            multipart::Part::text(metadata.to_string())
+                .mime_str("application/json")
+                .unwrap(),
+        )
+        .part(
+            "file",
+            multipart::Part::bytes(b"data".to_vec())
+                .file_name("encrypted")
+                .mime_str("application/octet-stream")
+                .unwrap(),
+        );
+
+    // First request should succeed
+    let resp = client
+        .post(format!("{}/api/paste", base_url))
+        .multipart(form)
+        .send()
+        .await
+        .unwrap();
     assert_eq!(resp.status(), 200);
 
-    // .txt should be allowed
-    let resp = create_paste(&client, &base_url, "notes.txt", b"data", false, 3600, None).await;
-    assert_eq!(resp.status(), 200);
+    // Second request with same paste ID should return 409 Conflict
+    let form2 = multipart::Form::new()
+        .part(
+            "metadata",
+            multipart::Part::text(metadata.to_string())
+                .mime_str("application/json")
+                .unwrap(),
+        )
+        .part(
+            "file",
+            multipart::Part::bytes(b"different data".to_vec())
+                .file_name("encrypted")
+                .mime_str("application/octet-stream")
+                .unwrap(),
+        );
+
+    let resp = client
+        .post(format!("{}/api/paste", base_url))
+        .multipart(form2)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 409);
 }
 
 // ============================================================================
@@ -950,16 +1001,7 @@ async fn test_admin_delete_paste() {
     let client = reqwest::Client::new();
 
     // Create a paste
-    let resp = create_paste(
-        &client,
-        &base_url,
-        "deleteme.txt",
-        b"data",
-        false,
-        3600,
-        None,
-    )
-    .await;
+    let resp = create_paste(&client, &base_url, "text", b"data", false, 3600, None).await;
     let body: serde_json::Value = resp.json().await.unwrap();
     let paste_id = body["id"].as_str().unwrap().to_string();
 
@@ -1023,7 +1065,7 @@ async fn test_admin_revoke_user() {
     let resp = create_paste(
         &client,
         &base_url,
-        "user_paste.md",
+        "text",
         b"data",
         false,
         3600,
@@ -1221,7 +1263,7 @@ async fn test_activate_user_on_first_upload() {
     let resp = create_paste(
         &client,
         &base_url,
-        "first.txt",
+        "text",
         b"first upload",
         false,
         3600,
@@ -1249,7 +1291,7 @@ async fn test_activate_user_on_first_upload() {
     let resp = create_paste(
         &client,
         &base_url,
-        "second.txt",
+        "text",
         b"second upload",
         false,
         3600,
@@ -1338,7 +1380,7 @@ async fn test_concurrent_burn_after_reading_race() {
     let resp = create_paste(
         &client,
         &base_url,
-        "race.txt",
+        "text",
         b"race condition test",
         true,
         3600,
@@ -1464,7 +1506,7 @@ async fn test_forever_paste_requires_auth() {
     let client = reqwest::Client::new();
 
     // Public user trying to create forever paste (ttl=0) should be rejected
-    let resp = create_paste(&client, &base_url, "forever.md", b"data", false, 0, None).await;
+    let resp = create_paste(&client, &base_url, "text", b"data", false, 0, None).await;
     assert_eq!(resp.status(), 403);
 
     // Login as admin (trusted user)
@@ -1474,7 +1516,7 @@ async fn test_forever_paste_requires_auth() {
     let resp = create_paste(
         &client,
         &base_url,
-        "forever.md",
+        "text",
         b"forever data",
         false,
         0,
@@ -1701,7 +1743,7 @@ async fn test_session_invalid_after_logout_on_all_endpoints() {
 }
 
 #[tokio::test]
-async fn test_trusted_user_can_upload_any_extension() {
+async fn test_trusted_user_can_upload_files() {
     let (base_url, _con, admin_key, admin_alias) = spawn_test_server().await;
     let client = reqwest::Client::new();
 
@@ -1712,12 +1754,12 @@ async fn test_trusted_user_can_upload_any_extension() {
     let (_user_key, _user_alias, user_token) =
         create_trusted_user(&client, &base_url, &admin_token).await;
 
-    // Trusted user can upload .exe (blocked for public)
+    // Trusted user can upload "file" type (blocked for public)
     let resp = create_paste(
         &client,
         &base_url,
-        "program.exe",
-        b"MZ...",
+        "file",
+        b"binary data",
         false,
         3600,
         Some(&user_token),
@@ -1725,38 +1767,12 @@ async fn test_trusted_user_can_upload_any_extension() {
     .await;
     assert_eq!(resp.status(), 200);
 
-    // Trusted user can upload .zip
+    // Trusted user can also create text pastes
     let resp = create_paste(
         &client,
         &base_url,
-        "archive.zip",
-        b"PK...",
-        false,
-        3600,
-        Some(&user_token),
-    )
-    .await;
-    assert_eq!(resp.status(), 200);
-
-    // Trusted user can upload .pdf
-    let resp = create_paste(
-        &client,
-        &base_url,
-        "document.pdf",
-        b"%PDF...",
-        false,
-        3600,
-        Some(&user_token),
-    )
-    .await;
-    assert_eq!(resp.status(), 200);
-
-    // Trusted user can upload file with no extension
-    let resp = create_paste(
-        &client,
-        &base_url,
-        "Makefile",
-        b"all: build",
+        "text",
+        b"some text",
         false,
         3600,
         Some(&user_token),


### PR DESCRIPTION
## Summary

- Frontend generates paste ID client-side and uses it as AES-GCM AAD, binding ciphertext to its identity
- Filename and content_type encrypted into opaque metadata blob (server never sees plaintext metadata)
- Backend accepts `paste_id`, `encrypted_metadata`, `paste_type` instead of `filename`/`content_type`
- SETNX-based paste storage prevents ID collisions (409 Conflict)
- Exclusive file create (`create_new`) with stale temp cleanup
- Backward compat for legacy pastes via `serde(default)` + `Option` fields

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test --lib` — 65 unit tests pass
- [x] `cargo test --test integration -- --test-threads=1` — 32 integration tests pass
- [x] `bash tools/verify-vendor.sh` — all SRI hashes correct
- [x] Manual browser test: create paste → view paste → decryption works
- [x] Duplicate paste ID returns 409
- [x] Public users restricted to text paste type