### PR TITLE
feat: add branded 404 page for unmatched routes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 use tower_http::cors::CorsLayer;
-use tower_http::services::ServeDir;
+use tower_http::services::{ServeDir, ServeFile};
 
 /// Generate Ed25519 keypair from alias + secret using Argon2id (same as JS client)
 fn keygen(alias: &str, secret: &str) -> Result<String, String> {
@@ -214,7 +214,9 @@ async fn main() {
     let cors = CorsLayer::new();
 
     let app = routes::api_router()
-        .fallback_service(ServeDir::new("static"))
+        .fallback_service(
+            ServeDir::new("static").not_found_service(ServeFile::new("static/404.html")),
+        )
         .layer(axum::extract::DefaultBodyLimit::max(
             config.max_upload_bytes,
         ))

--- a/static/404.html
+++ b/static/404.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>404 - Nullpad</title>
+  <link rel="icon" href="/favicon.svg">
+  <link rel="stylesheet" href="/css/style.css" integrity="sha384-wLQft9mrat9TdbuEsRPwOh1K1RSQW1Y+iK29KNydw2R+YaclFKv2eKKaPO1MatzF" crossorigin="anonymous">
+</head>
+<body>
+  <a href="#main-content" class="skip-link">Skip to content</a>
+  <div class="container" id="main-content">
+    <div class="page-header">
+      <h1>404 — Not Found</h1>
+      <p>The page you're looking for doesn't exist.</p>
+    </div>
+
+    <div class="panel-footer">
+      <a href="/" class="btn btn-secondary">Back to Nullpad</a>
+    </div>
+  </div>
+
+  <footer class="site-footer">
+    <a href="https://github.com/angeswe/nullpad" target="_blank" rel="noopener">GitHub</a>
+    <span class="build-version">__BUILD_VERSION__</span>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add `static/404.html` matching the dark terminal aesthetic (same template as `info.html`)
- Use `ServeDir::not_found_service(ServeFile::new(...))` to serve it when no route matches
- SRI hashes regenerated

## Test plan
- [x] `cargo build` compiles
- [x] `cargo test --lib` passes (64 tests)
- [x] Visit nonexistent route (e.g. `/asdf`) — shows branded 404 page
- [x] Visit existing routes (`/`, `/info.html`) — still work normally