### PR TITLE
fix: address security audit findings

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,7 +1,9 @@
 # Multi-stage build with cross-compilation for arm64
 
 # Stage 1: Build (on native platform, cross-compile to arm64)
-FROM --platform=$BUILDPLATFORM rust:slim-bookworm AS builder
+# Pin base images by digest for reproducible builds.
+# To update: docker pull rust:slim-bookworm && docker inspect --format='{{index .RepoDigests 0}}' rust:slim-bookworm
+FROM --platform=$BUILDPLATFORM rust:slim-bookworm@sha256:5b9332190bb3b9ece73b810cd1f1e9f06343b294ce184bcb067f0747d7d333ea AS builder
 
 # Install cross-compilation toolchain
 RUN dpkg --add-architecture arm64 && \
@@ -32,7 +34,8 @@ COPY src ./src
 RUN cargo build --release --target aarch64-unknown-linux-gnu
 
 # Stage 2: Runtime (arm64 — platform set by buildx)
-FROM debian:bookworm-slim
+# To update: docker pull debian:bookworm-slim && docker inspect --format='{{index .RepoDigests 0}}' debian:bookworm-slim
+FROM debian:bookworm-slim@sha256:74d56e3931e0d5a1dd51f8c8a2466d21de84a271cd3b5a733b803aa91abf4421
 
 # Install runtime dependencies and apply security updates
 RUN apt-get update && \
@@ -67,8 +70,11 @@ RUN apt-get update && \
 ARG BUILD_VERSION=dev
 RUN sed -i "s/__BUILD_VERSION__/${BUILD_VERSION}/g" /app/static/*.html
 
+# Create paste storage directory
+RUN mkdir -p /data/pastes
+
 # Ensure static files are world-readable and change ownership
-RUN chmod -R a+rX /app/static && chown -R nullpad:nullpad /app
+RUN chmod -R a+rX /app/static && chown -R nullpad:nullpad /app /data
 
 # Switch to non-root user
 USER nullpad

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,8 @@ services:
       - /tmp
 
   redis:
-    image: redis:7-alpine
+    # To update: docker pull redis:7-alpine && docker inspect --format='{{index .RepoDigests 0}}' redis:7-alpine
+    image: redis:7-alpine@sha256:8b81dd37ff027bec4e516d41acfbe9fe2460070dc6d4a4570a2ac5b9d59df065
     user: redis
     volumes:
       - redis-data:/data

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,12 +63,14 @@ fn keygen(alias: &str, secret: &str) -> Result<String, String> {
 }
 
 fn print_keygen_usage() {
-    eprintln!("Usage: nullpad keygen <alias> <secret>");
+    eprintln!("Usage: nullpad keygen <alias>");
     eprintln!();
     eprintln!("Generate Ed25519 public key from alias + secret for ADMIN_PUBKEY.");
+    eprintln!("Secret is read from stdin (not CLI args, to avoid process list exposure).");
     eprintln!();
     eprintln!("Example:");
-    eprintln!("  nullpad keygen admin mysecretpassword");
+    eprintln!("  echo -n 'mysecretpassword' | nullpad keygen admin");
+    eprintln!("  nullpad keygen admin  # prompts interactively");
     eprintln!();
     eprintln!("Then set in .env:");
     eprintln!("  ADMIN_ALIAS=admin");
@@ -111,14 +113,33 @@ async fn main() {
     // Check for keygen subcommand
     let args: Vec<String> = std::env::args().collect();
     if args.len() >= 2 && args[1] == "keygen" {
-        if args.len() != 4 {
+        if args.len() != 3 {
             print_keygen_usage();
             std::process::exit(1);
         }
         let alias = &args[2];
-        let secret = &args[3];
 
-        match keygen(alias, secret) {
+        // Read secret from stdin to avoid process list exposure (/proc/pid/cmdline)
+        let secret = {
+            use std::io::{self, BufRead, IsTerminal, Write};
+            if io::stdin().is_terminal() {
+                eprint!("Enter secret: ");
+                io::stderr().flush().ok();
+            }
+            let mut line = String::new();
+            io::stdin()
+                .lock()
+                .read_line(&mut line)
+                .expect("Failed to read secret from stdin");
+            let trimmed = line.trim_end_matches('\n').trim_end_matches('\r');
+            if trimmed.is_empty() {
+                eprintln!("Error: secret cannot be empty");
+                std::process::exit(1);
+            }
+            trimmed.to_string()
+        };
+
+        match keygen(alias, &secret) {
             Ok(pubkey) => {
                 println!("{}", pubkey);
             }

--- a/src/routes/auth.rs
+++ b/src/routes/auth.rs
@@ -224,16 +224,11 @@ pub async fn register(
 
     match created {
         storage::user::RegisterResult::Success => {}
-        storage::user::RegisterResult::AliasTaken => {
-            return Err(AppError::BadRequest(format!(
-                "Alias '{}' is already taken",
-                req.alias
-            )));
-        }
-        storage::user::RegisterResult::InviteNotFound => {
-            return Err(AppError::NotFound(
-                "Invite not found or expired".to_string(),
-            ));
+        storage::user::RegisterResult::AliasTaken
+        | storage::user::RegisterResult::InviteNotFound => {
+            // Uniform error prevents alias enumeration (attacker can't distinguish
+            // "alias taken" from "bad invite" without a valid invite token).
+            return Err(AppError::BadRequest("Registration failed".to_string()));
         }
     }
 

--- a/static/admin.html
+++ b/static/admin.html
@@ -126,8 +126,8 @@
     <span class="build-version">__BUILD_VERSION__</span>
   </footer>
 
-  <script src="/js/vendor/argon2.umd.min.js" integrity="sha384-tP0Wy54CKmng7i9EoTlPySD0hBx6Octj0VS6MfwlnUu111MPa+JLm0CCbep6XJ1W"></script>
-  <script src="/js/auth.js" integrity="sha384-OC5YYRrtpzvzXVbk9Jlns+kEWgxFrD6cYA6wPV5RkuYOB9DhN51beYOXISeTD/QZ"></script>
-  <script src="/js/admin.js" integrity="sha384-Fp+DK5t2t8vb1XR6m5XVHxQjbGiQJxoKOVU/6jUBsRGhzzCPjdX85xgEbyoSI92f"></script>
+  <script src="/js/vendor/argon2.umd.min.js" integrity="sha384-tP0Wy54CKmng7i9EoTlPySD0hBx6Octj0VS6MfwlnUu111MPa+JLm0CCbep6XJ1W" crossorigin="anonymous"></script>
+  <script src="/js/auth.js" integrity="sha384-OC5YYRrtpzvzXVbk9Jlns+kEWgxFrD6cYA6wPV5RkuYOB9DhN51beYOXISeTD/QZ" crossorigin="anonymous"></script>
+  <script src="/js/admin.js" integrity="sha384-Fp+DK5t2t8vb1XR6m5XVHxQjbGiQJxoKOVU/6jUBsRGhzzCPjdX85xgEbyoSI92f" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/static/index.html
+++ b/static/index.html
@@ -91,8 +91,8 @@
     <span class="build-version">__BUILD_VERSION__</span>
   </footer>
 
-  <script src="/js/vendor/argon2.umd.min.js" integrity="sha384-tP0Wy54CKmng7i9EoTlPySD0hBx6Octj0VS6MfwlnUu111MPa+JLm0CCbep6XJ1W"></script>
-  <script src="/js/crypto.js" integrity="sha384-L4s53PBPpJg1PnQa/gidQSD96ByUFqquNwXFrtbc1g55V/9Al/Dv7Yg6/O9c6VQd"></script>
-  <script src="/js/create.js" integrity="sha384-emd9Ek+HuyZA1nHUGtXyBFsI6nr0lQKD7Q00lNeCiN6piUGvb0W0D113m07UH/tk"></script>
+  <script src="/js/vendor/argon2.umd.min.js" integrity="sha384-tP0Wy54CKmng7i9EoTlPySD0hBx6Octj0VS6MfwlnUu111MPa+JLm0CCbep6XJ1W" crossorigin="anonymous"></script>
+  <script src="/js/crypto.js" integrity="sha384-L4s53PBPpJg1PnQa/gidQSD96ByUFqquNwXFrtbc1g55V/9Al/Dv7Yg6/O9c6VQd" crossorigin="anonymous"></script>
+  <script src="/js/create.js" integrity="sha384-emd9Ek+HuyZA1nHUGtXyBFsI6nr0lQKD7Q00lNeCiN6piUGvb0W0D113m07UH/tk" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/static/invite.html
+++ b/static/invite.html
@@ -85,8 +85,8 @@
     <span class="build-version">__BUILD_VERSION__</span>
   </footer>
 
-  <script src="/js/vendor/argon2.umd.min.js" integrity="sha384-tP0Wy54CKmng7i9EoTlPySD0hBx6Octj0VS6MfwlnUu111MPa+JLm0CCbep6XJ1W"></script>
-  <script src="/js/auth.js" integrity="sha384-OC5YYRrtpzvzXVbk9Jlns+kEWgxFrD6cYA6wPV5RkuYOB9DhN51beYOXISeTD/QZ"></script>
-  <script src="/js/invite.js" integrity="sha384-7cS5jdLgwcaSMRrO8IzEiRXW1H6N7Ja2UC+1Ld/9gUxamt//Y2G5yetnJ59lnQt0"></script>
+  <script src="/js/vendor/argon2.umd.min.js" integrity="sha384-tP0Wy54CKmng7i9EoTlPySD0hBx6Octj0VS6MfwlnUu111MPa+JLm0CCbep6XJ1W" crossorigin="anonymous"></script>
+  <script src="/js/auth.js" integrity="sha384-OC5YYRrtpzvzXVbk9Jlns+kEWgxFrD6cYA6wPV5RkuYOB9DhN51beYOXISeTD/QZ" crossorigin="anonymous"></script>
+  <script src="/js/invite.js" integrity="sha384-7cS5jdLgwcaSMRrO8IzEiRXW1H6N7Ja2UC+1Ld/9gUxamt//Y2G5yetnJ59lnQt0" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/static/js/view.js
+++ b/static/js/view.js
@@ -186,10 +186,10 @@
         try {
           const metaBytes = await NullpadCrypto.decrypt(metadata.encrypted_metadata, decryptionKey, pasteId);
           const fileMeta = JSON.parse(new TextDecoder().decode(metaBytes));
-          if (fileMeta.filename) metadata.filename = fileMeta.filename;
-          if (fileMeta.content_type) metadata.mimetype = fileMeta.content_type;
+          if (typeof fileMeta.filename === 'string') metadata.filename = fileMeta.filename;
+          if (typeof fileMeta.content_type === 'string') metadata.mimetype = fileMeta.content_type;
         } catch {
-          console.warn('Failed to decrypt encrypted_metadata; falling back to server-provided plaintext metadata');
+          // Fallback to server-provided plaintext metadata (legacy pastes)
         }
       }
 
@@ -199,7 +199,7 @@
       try {
         bytes = await NullpadCrypto.decrypt(encryptedData, decryptionKey, pasteId);
       } catch {
-        console.warn('AAD decryption failed; falling back to non-AAD decryption for backward compatibility');
+        // Fallback to non-AAD decryption (backward compat for old pastes)
         bytes = await NullpadCrypto.decrypt(encryptedData, decryptionKey);
       }
 

--- a/static/login.html
+++ b/static/login.html
@@ -58,8 +58,8 @@
     <span class="build-version">__BUILD_VERSION__</span>
   </footer>
 
-  <script src="/js/vendor/argon2.umd.min.js" integrity="sha384-tP0Wy54CKmng7i9EoTlPySD0hBx6Octj0VS6MfwlnUu111MPa+JLm0CCbep6XJ1W"></script>
-  <script src="/js/auth.js" integrity="sha384-OC5YYRrtpzvzXVbk9Jlns+kEWgxFrD6cYA6wPV5RkuYOB9DhN51beYOXISeTD/QZ"></script>
-  <script src="/js/login.js" integrity="sha384-c270mg6IoZ0hOhBHi+JVMMtK9IwAE7RE7cUZhgMtcxsgGFGg7xjGk+C0kRXpmlM4"></script>
+  <script src="/js/vendor/argon2.umd.min.js" integrity="sha384-tP0Wy54CKmng7i9EoTlPySD0hBx6Octj0VS6MfwlnUu111MPa+JLm0CCbep6XJ1W" crossorigin="anonymous"></script>
+  <script src="/js/auth.js" integrity="sha384-OC5YYRrtpzvzXVbk9Jlns+kEWgxFrD6cYA6wPV5RkuYOB9DhN51beYOXISeTD/QZ" crossorigin="anonymous"></script>
+  <script src="/js/login.js" integrity="sha384-c270mg6IoZ0hOhBHi+JVMMtK9IwAE7RE7cUZhgMtcxsgGFGg7xjGk+C0kRXpmlM4" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/static/trusted.html
+++ b/static/trusted.html
@@ -107,10 +107,10 @@
     <span class="build-version">__BUILD_VERSION__</span>
   </footer>
 
-  <script src="/js/vendor/argon2.umd.min.js" integrity="sha384-tP0Wy54CKmng7i9EoTlPySD0hBx6Octj0VS6MfwlnUu111MPa+JLm0CCbep6XJ1W"></script>
-  <script src="/js/crypto.js" integrity="sha384-L4s53PBPpJg1PnQa/gidQSD96ByUFqquNwXFrtbc1g55V/9Al/Dv7Yg6/O9c6VQd"></script>
-  <script src="/js/auth.js" integrity="sha384-OC5YYRrtpzvzXVbk9Jlns+kEWgxFrD6cYA6wPV5RkuYOB9DhN51beYOXISeTD/QZ"></script>
-  <script src="/js/create.js" integrity="sha384-emd9Ek+HuyZA1nHUGtXyBFsI6nr0lQKD7Q00lNeCiN6piUGvb0W0D113m07UH/tk"></script>
-  <script src="/js/trusted.js" integrity="sha384-wD4K/p/w1yS+yG9H9WP1Co0/TJmy2sUwC5iW6zEYPmGvptqUENoVprXBdHHz+3Mr"></script>
+  <script src="/js/vendor/argon2.umd.min.js" integrity="sha384-tP0Wy54CKmng7i9EoTlPySD0hBx6Octj0VS6MfwlnUu111MPa+JLm0CCbep6XJ1W" crossorigin="anonymous"></script>
+  <script src="/js/crypto.js" integrity="sha384-L4s53PBPpJg1PnQa/gidQSD96ByUFqquNwXFrtbc1g55V/9Al/Dv7Yg6/O9c6VQd" crossorigin="anonymous"></script>
+  <script src="/js/auth.js" integrity="sha384-OC5YYRrtpzvzXVbk9Jlns+kEWgxFrD6cYA6wPV5RkuYOB9DhN51beYOXISeTD/QZ" crossorigin="anonymous"></script>
+  <script src="/js/create.js" integrity="sha384-emd9Ek+HuyZA1nHUGtXyBFsI6nr0lQKD7Q00lNeCiN6piUGvb0W0D113m07UH/tk" crossorigin="anonymous"></script>
+  <script src="/js/trusted.js" integrity="sha384-wD4K/p/w1yS+yG9H9WP1Co0/TJmy2sUwC5iW6zEYPmGvptqUENoVprXBdHHz+3Mr" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/static/view.html
+++ b/static/view.html
@@ -85,11 +85,11 @@
     <span class="build-version">__BUILD_VERSION__</span>
   </footer>
 
-  <script src="/js/vendor/marked.min.js" integrity="sha384-KwzR5her+zXi/Bzz4PVrBjkrjsBZy9adZtt3jA6Jgj3/hzPihRUV6HqMONpTe7Ll"></script>
-  <script src="/js/vendor/highlight.min.js" integrity="sha384-RH2xi4eIQ/gjtbs9fUXM68sLSi99C7ZWBRX1vDrVv6GQXRibxXLbwO2NGZB74MbU"></script>
-  <script src="/js/vendor/purify.min.js" integrity="sha384-80VlBZnyAwkkqtSfg5NhPyZff6nU4K/qniLBL8Jnm4KDv6jZhLiYtJbhglg/i9ww"></script>
-  <script src="/js/vendor/argon2.umd.min.js" integrity="sha384-tP0Wy54CKmng7i9EoTlPySD0hBx6Octj0VS6MfwlnUu111MPa+JLm0CCbep6XJ1W"></script>
-  <script src="/js/crypto.js" integrity="sha384-L4s53PBPpJg1PnQa/gidQSD96ByUFqquNwXFrtbc1g55V/9Al/Dv7Yg6/O9c6VQd"></script>
-  <script src="/js/view.js" integrity="sha384-K2jD53LdMPG4fHKt66Iy7kGaOWnwwv5G6VtbHcKAWD6yv4cWsyctxrhm9r9oE+tN"></script>
+  <script src="/js/vendor/marked.min.js" integrity="sha384-KwzR5her+zXi/Bzz4PVrBjkrjsBZy9adZtt3jA6Jgj3/hzPihRUV6HqMONpTe7Ll" crossorigin="anonymous"></script>
+  <script src="/js/vendor/highlight.min.js" integrity="sha384-RH2xi4eIQ/gjtbs9fUXM68sLSi99C7ZWBRX1vDrVv6GQXRibxXLbwO2NGZB74MbU" crossorigin="anonymous"></script>
+  <script src="/js/vendor/purify.min.js" integrity="sha384-80VlBZnyAwkkqtSfg5NhPyZff6nU4K/qniLBL8Jnm4KDv6jZhLiYtJbhglg/i9ww" crossorigin="anonymous"></script>
+  <script src="/js/vendor/argon2.umd.min.js" integrity="sha384-tP0Wy54CKmng7i9EoTlPySD0hBx6Octj0VS6MfwlnUu111MPa+JLm0CCbep6XJ1W" crossorigin="anonymous"></script>
+  <script src="/js/crypto.js" integrity="sha384-L4s53PBPpJg1PnQa/gidQSD96ByUFqquNwXFrtbc1g55V/9Al/Dv7Yg6/O9c6VQd" crossorigin="anonymous"></script>
+  <script src="/js/view.js" integrity="sha384-wo45p44gPvAjxSEHQIDIdmsU7Na5XDONqJdgbLYiR5JcvHH2Gbpu/Xz37YTgDA+M" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -553,7 +553,7 @@ async fn test_register_invalid_invite() {
         .unwrap();
     assert_eq!(resp.status(), 400);
 
-    // Valid-format but non-existent token → 404
+    // Valid-format but non-existent token → 400 (uniform error prevents alias enumeration)
     let resp = client
         .post(format!("{}/api/register", base_url))
         .json(&serde_json::json!({
@@ -564,7 +564,12 @@ async fn test_register_invalid_invite() {
         .send()
         .await
         .unwrap();
-    assert_eq!(resp.status(), 404);
+    assert_eq!(resp.status(), 400);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert!(body["error"]
+        .as_str()
+        .unwrap()
+        .contains("Registration failed"));
 }
 
 #[tokio::test]
@@ -777,7 +782,10 @@ async fn test_register_invite_not_consumed_on_validation_failure() {
         .unwrap();
     assert_eq!(resp.status(), 400);
     let body: serde_json::Value = resp.json().await.unwrap();
-    assert!(body["error"].as_str().unwrap().contains("already taken"));
+    assert!(body["error"]
+        .as_str()
+        .unwrap()
+        .contains("Registration failed"));
 
     // Verify invite still exists after alias conflict
     let exists: bool = con.exists(&invite_key).await.unwrap();

--- a/tools/update-sri.sh
+++ b/tools/update-sri.sh
@@ -27,7 +27,7 @@ for html in $HTML_FILES; do
 
     # Replace: src="/js/..." with or without existing integrity
     # Match: <script src="/js/path"[optional integrity]></script>
-    sed -i "s|<script src=\"${src_path}\"[^>]*>|<script src=\"${src_path}\" integrity=\"${hash}\">|g" "$html"
+    sed -i "s|<script src=\"${src_path}\"[^>]*>|<script src=\"${src_path}\" integrity=\"${hash}\" crossorigin=\"anonymous\">|g" "$html"
   done || true
   echo "Updated: $html"
 done


### PR DESCRIPTION
## Summary

Comprehensive security audit identified 9 actionable findings across backend, frontend, and infrastructure. This PR addresses all of them.

### Fixes

| Priority | Finding | Fix |
|----------|---------|-----|
| P1 | `keygen` exposes secret in process list (`/proc/pid/cmdline`) | Read secret from stdin; interactive prompt when terminal detected |
| P1 | `Dockerfile.prod` uses unpinned base images (supply chain risk) | Pin `rust:slim-bookworm` and `debian:bookworm-slim` by SHA256 digest |
| P2 | `Dockerfile.prod` missing `/data/pastes` dir + ownership | Add `mkdir -p /data/pastes` and `chown /data` (matches primary Dockerfile) |
| P2 | Redis image tag not pinned by digest | Pin `redis:7-alpine` by SHA256 digest in docker-compose |
| P2 | Registration leaks alias existence ("already taken" vs "bad invite") | Uniform "Registration failed" error for both cases |
| P2 | `console.warn` in view.js reveals encryption format details | Replace with silent comments |
| P3 | `JSON.parse` of decrypted metadata lacks type validation | Add `typeof === 'string'` checks |
| P3 | Script tags missing `crossorigin="anonymous"` (SRI consistency) | Add to all `<script>` tags; update `update-sri.sh` |
| P2 | CSP `img-src blob:` — investigated, **needed** for image preview | Closed as won't-fix (`URL.createObjectURL` in view.js) |

### Audit Summary (no code changes needed)

- **Zero-knowledge: PASS** — server never sees plaintext, keys, PINs, or secrets
- **Path traversal: clean** — `sanitize_blob_id` + `canonicalize_storage_root` + `strip_prefix`
- **XSS: clean** — DOMPurify + strict CSP + SRI on all scripts
- **Auth: clean** — Ed25519 challenge-response, atomic Lua scripts, anti-enumeration
- **Rate limiting: clean** — atomic Lua INCR+EXPIRE on all endpoints

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test --lib` — 64 unit tests pass
- [x] `cargo test --test integration -- --test-threads=1` — 32 integration tests pass
- [x] `bash tools/verify-vendor.sh` — vendor integrity + SRI hashes verified
- [x] CI/security review agents: no issues found
- [x] Zero-knowledge audit agent: no violations