### PR TITLE
chore(deps): bump aws-lc-sys to 0.39.0 (security fix)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,9 +55,9 @@ dependencies = [
 
 [[package]]
 name = "astral-tokio-tar"
-version = "0.5.6"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec179a06c1769b1e42e1e2cbe74c7dcdb3d6383c838454d063eaac5bbb7ebbe5"
+checksum = "3c23f3af104b40a3430ccb90ed5f7bd877a8dc5c26fc92fde51a22b40890dcf9"
 dependencies = [
  "filetime",
  "futures-core",
@@ -2187,9 +2187,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -2591,9 +2591,9 @@ dependencies = [
 
 [[package]]
 name = "testcontainers"
-version = "0.27.1"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1c0624faaa317c56d6d19136580be889677259caf5c897941c6f446b4655068"
+checksum = "0bd36b06a2a6c0c3c81a83be1ab05fe86460d054d4d51bf513bc56b3e15bdc22"
 dependencies = [
  "astral-tokio-tar",
  "async-trait",


### PR DESCRIPTION
## Summary
- Updates `aws-lc-sys` 0.38.0 → 0.39.0 (via `aws-lc-rs` 1.16.1 → 1.16.2)
- Updates `rustls-webpki` 0.103.9 → 0.103.10
- Updates `astral-tokio-tar` 0.5.6 → 0.6.0 (via `testcontainers` 0.27.1 → 0.27.2)

### Advisories fixed
| Advisory | Package | Issue |
|----------|---------|-------|
| RUSTSEC-2026-0044 | aws-lc-sys | X.509 Name Constraints bypass via wildcard/unicode CN |
| RUSTSEC-2026-0048 | aws-lc-sys | CRL Distribution Point scope check logic error |
| RUSTSEC-2026-0049 | rustls-webpki | CRL Distribution Point faulty matching logic |
| RUSTSEC-2026-0066 | astral-tokio-tar | Insufficient PAX extension validation |

## Test plan
- [x] All 66 unit tests pass
- [x] All 39 integration tests pass
- [x] CI security audit job passes