### PR TITLE
chore: tighten supply chain pinning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,8 @@ jobs:
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
       - name: Start Redis with authentication
         run: |
-          docker run -d --name redis -p 6379:6379 redis:7-alpine \
+          docker run -d --name redis -p 6379:6379 \
+            redis:7-alpine@sha256:8b81dd37ff027bec4e516d41acfbe9fe2460070dc6d4a4570a2ac5b9d59df065 \
             redis-server --requirepass ci-test-pass
           for i in $(seq 1 30); do
             if docker exec redis redis-cli -a ci-test-pass ping 2>/dev/null | grep -q PONG; then
@@ -35,11 +36,11 @@ jobs:
       - name: Verify vendor JS hashes and SRI attributes
         run: bash tools/verify-vendor.sh
       - name: Unit tests
-        run: cargo test --lib
+        run: cargo test --locked --lib
         env:
           REDIS_URL: redis://:ci-test-pass@127.0.0.1:6379
       - name: Integration tests (sequential, shared Redis)
-        run: cargo test --test integration -- --test-threads=1
+        run: cargo test --locked --test integration -- --test-threads=1
         env:
           REDIS_URL: redis://:ci-test-pass@127.0.0.1:6379
 
@@ -55,7 +56,7 @@ jobs:
           components: clippy, rustfmt
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
       - run: cargo fmt --check
-      - run: cargo clippy -- -D warnings
+      - run: cargo clippy --locked -- -D warnings
 
   audit:
     name: Security Audit

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -26,12 +26,12 @@ COPY Cargo.toml Cargo.lock ./
 RUN mkdir -p src tests && \
     echo "fn main() {}" > src/main.rs && \
     touch src/lib.rs tests/integration.rs && \
-    cargo build --release --target aarch64-unknown-linux-gnu && \
+    cargo build --release --locked --target aarch64-unknown-linux-gnu && \
     rm -rf src target/aarch64-unknown-linux-gnu/release/nullpad target/aarch64-unknown-linux-gnu/release/deps/nullpad-* target/aarch64-unknown-linux-gnu/release/.fingerprint/nullpad-*
 
 # Copy source code and build for real
 COPY src ./src
-RUN cargo build --release --target aarch64-unknown-linux-gnu
+RUN cargo build --release --locked --target aarch64-unknown-linux-gnu
 
 # Stage 2: Runtime (arm64 — platform set by buildx)
 # To update: docker pull debian:bookworm-slim && docker inspect --format='{{index .RepoDigests 0}}' debian:bookworm-slim


### PR DESCRIPTION
## Summary
- Add \`--locked\` to CI \`cargo test\`/\`cargo clippy\` so a stale \`Cargo.lock\` fails the build instead of being silently rewritten
- Add \`--locked\` to \`Dockerfile.prod\` cargo builds (matches \`Dockerfile\`)
- Pin \`redis:7-alpine\` by SHA256 digest in the CI test job (was tag-only)

## Test plan
- [x] \`cargo fmt --check\` / \`cargo clippy --locked -- -D warnings\`
- [x] \`cargo test --locked --lib\` passes locally
- [x] CI green