### PR TITLE
feat(viewer): widen paste viewer for markdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -724,7 +724,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1601,7 +1601,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2148,9 +2148,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2227,7 +2227,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2286,7 +2286,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2585,7 +2585,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2707,7 +2707,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3361,7 +3361,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,9 +55,9 @@ dependencies = [
 
 [[package]]
 name = "astral-tokio-tar"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c23f3af104b40a3430ccb90ed5f7bd877a8dc5c26fc92fde51a22b40890dcf9"
+checksum = "4ce73b17c62717c4b6a9af10b43e87c578b0cac27e00666d48304d3b7d2c0693"
 dependencies = [
  "filetime",
  "futures-core",
@@ -724,7 +724,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1601,7 +1601,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2227,7 +2227,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2286,7 +2286,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2585,7 +2585,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2707,7 +2707,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3361,7 +3361,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ strip = true
 lto = true
 
 [dev-dependencies]
-reqwest = { version = "0.13.2", features = ["json", "multipart"] }
+reqwest = { version = "0.13.3", features = ["json", "multipart"] }
 testcontainers-modules = { version = "0.15", features = ["redis"] }
 tempfile = "3"
 futures = "0.3"

--- a/protected/admin.html
+++ b/protected/admin.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Admin Dashboard - Nullpad</title>
   <link rel="icon" href="/favicon.svg">
-  <link rel="stylesheet" href="/css/style.css" integrity="sha384-ZmOeqL3wZc4O97qSjoY54T/oQXBBkHJe3iuz4xlo718Ggl5TalMQPVLSPwK3um64" crossorigin="anonymous">
+  <link rel="stylesheet" href="/css/style.css" integrity="sha384-z2SKY2YGmInhpP4jL+UTEEc0zlifc/3VqFyqr+mLEvgh6LZ/+4bQ5GdvzRIZg5XS" crossorigin="anonymous">
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to content</a>

--- a/protected/admin.html
+++ b/protected/admin.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Admin Dashboard - Nullpad</title>
   <link rel="icon" href="/favicon.svg">
-  <link rel="stylesheet" href="/css/style.css" integrity="sha384-/TvQok4/FK0trD4rGkJJX7fjbTrsOl/TKa7x8xx1uxiizTBGql/rrKSosJCC+r6g" crossorigin="anonymous">
+  <link rel="stylesheet" href="/css/style.css" integrity="sha384-ZmOeqL3wZc4O97qSjoY54T/oQXBBkHJe3iuz4xlo718Ggl5TalMQPVLSPwK3um64" crossorigin="anonymous">
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to content</a>

--- a/protected/trusted.html
+++ b/protected/trusted.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Trusted Upload - Nullpad</title>
   <link rel="icon" href="/favicon.svg">
-  <link rel="stylesheet" href="/css/style.css" integrity="sha384-/TvQok4/FK0trD4rGkJJX7fjbTrsOl/TKa7x8xx1uxiizTBGql/rrKSosJCC+r6g" crossorigin="anonymous">
+  <link rel="stylesheet" href="/css/style.css" integrity="sha384-ZmOeqL3wZc4O97qSjoY54T/oQXBBkHJe3iuz4xlo718Ggl5TalMQPVLSPwK3um64" crossorigin="anonymous">
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to content</a>

--- a/protected/trusted.html
+++ b/protected/trusted.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Trusted Upload - Nullpad</title>
   <link rel="icon" href="/favicon.svg">
-  <link rel="stylesheet" href="/css/style.css" integrity="sha384-ZmOeqL3wZc4O97qSjoY54T/oQXBBkHJe3iuz4xlo718Ggl5TalMQPVLSPwK3um64" crossorigin="anonymous">
+  <link rel="stylesheet" href="/css/style.css" integrity="sha384-z2SKY2YGmInhpP4jL+UTEEc0zlifc/3VqFyqr+mLEvgh6LZ/+4bQ5GdvzRIZg5XS" crossorigin="anonymous">
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to content</a>

--- a/static/404.html
+++ b/static/404.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>404 - Nullpad</title>
   <link rel="icon" href="/favicon.svg">
-  <link rel="stylesheet" href="/css/style.css" integrity="sha384-/TvQok4/FK0trD4rGkJJX7fjbTrsOl/TKa7x8xx1uxiizTBGql/rrKSosJCC+r6g" crossorigin="anonymous">
+  <link rel="stylesheet" href="/css/style.css" integrity="sha384-ZmOeqL3wZc4O97qSjoY54T/oQXBBkHJe3iuz4xlo718Ggl5TalMQPVLSPwK3um64" crossorigin="anonymous">
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to content</a>

--- a/static/404.html
+++ b/static/404.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>404 - Nullpad</title>
   <link rel="icon" href="/favicon.svg">
-  <link rel="stylesheet" href="/css/style.css" integrity="sha384-ZmOeqL3wZc4O97qSjoY54T/oQXBBkHJe3iuz4xlo718Ggl5TalMQPVLSPwK3um64" crossorigin="anonymous">
+  <link rel="stylesheet" href="/css/style.css" integrity="sha384-z2SKY2YGmInhpP4jL+UTEEc0zlifc/3VqFyqr+mLEvgh6LZ/+4bQ5GdvzRIZg5XS" crossorigin="anonymous">
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to content</a>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -139,6 +139,10 @@ pre code {
   padding: 2rem 1rem;
 }
 
+.container--wide {
+  max-width: 1100px;
+}
+
 .page-header {
   margin-bottom: 2rem;
   padding-bottom: 1rem;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -134,13 +134,9 @@ pre code {
    ========================================================================== */
 
 .container {
-  max-width: 700px;
+  max-width: 1100px;
   margin: 0 auto;
   padding: 2rem 1rem;
-}
-
-.container--wide {
-  max-width: 1100px;
 }
 
 .page-header {

--- a/static/index.html
+++ b/static/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Nullpad - Zero-knowledge Encrypted Paste Sharing</title>
   <link rel="icon" href="/favicon.svg">
-  <link rel="stylesheet" href="/css/style.css" integrity="sha384-/TvQok4/FK0trD4rGkJJX7fjbTrsOl/TKa7x8xx1uxiizTBGql/rrKSosJCC+r6g" crossorigin="anonymous">
+  <link rel="stylesheet" href="/css/style.css" integrity="sha384-ZmOeqL3wZc4O97qSjoY54T/oQXBBkHJe3iuz4xlo718Ggl5TalMQPVLSPwK3um64" crossorigin="anonymous">
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to content</a>

--- a/static/index.html
+++ b/static/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Nullpad - Zero-knowledge Encrypted Paste Sharing</title>
   <link rel="icon" href="/favicon.svg">
-  <link rel="stylesheet" href="/css/style.css" integrity="sha384-ZmOeqL3wZc4O97qSjoY54T/oQXBBkHJe3iuz4xlo718Ggl5TalMQPVLSPwK3um64" crossorigin="anonymous">
+  <link rel="stylesheet" href="/css/style.css" integrity="sha384-z2SKY2YGmInhpP4jL+UTEEc0zlifc/3VqFyqr+mLEvgh6LZ/+4bQ5GdvzRIZg5XS" crossorigin="anonymous">
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to content</a>

--- a/static/info.html
+++ b/static/info.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>How It Works - Nullpad</title>
   <link rel="icon" href="/favicon.svg">
-  <link rel="stylesheet" href="/css/style.css" integrity="sha384-ZmOeqL3wZc4O97qSjoY54T/oQXBBkHJe3iuz4xlo718Ggl5TalMQPVLSPwK3um64" crossorigin="anonymous">
+  <link rel="stylesheet" href="/css/style.css" integrity="sha384-z2SKY2YGmInhpP4jL+UTEEc0zlifc/3VqFyqr+mLEvgh6LZ/+4bQ5GdvzRIZg5XS" crossorigin="anonymous">
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to content</a>

--- a/static/info.html
+++ b/static/info.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>How It Works - Nullpad</title>
   <link rel="icon" href="/favicon.svg">
-  <link rel="stylesheet" href="/css/style.css" integrity="sha384-/TvQok4/FK0trD4rGkJJX7fjbTrsOl/TKa7x8xx1uxiizTBGql/rrKSosJCC+r6g" crossorigin="anonymous">
+  <link rel="stylesheet" href="/css/style.css" integrity="sha384-ZmOeqL3wZc4O97qSjoY54T/oQXBBkHJe3iuz4xlo718Ggl5TalMQPVLSPwK3um64" crossorigin="anonymous">
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to content</a>

--- a/static/invite.html
+++ b/static/invite.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Register - Nullpad</title>
   <link rel="icon" href="/favicon.svg">
-  <link rel="stylesheet" href="/css/style.css" integrity="sha384-/TvQok4/FK0trD4rGkJJX7fjbTrsOl/TKa7x8xx1uxiizTBGql/rrKSosJCC+r6g" crossorigin="anonymous">
+  <link rel="stylesheet" href="/css/style.css" integrity="sha384-ZmOeqL3wZc4O97qSjoY54T/oQXBBkHJe3iuz4xlo718Ggl5TalMQPVLSPwK3um64" crossorigin="anonymous">
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to content</a>

--- a/static/invite.html
+++ b/static/invite.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Register - Nullpad</title>
   <link rel="icon" href="/favicon.svg">
-  <link rel="stylesheet" href="/css/style.css" integrity="sha384-ZmOeqL3wZc4O97qSjoY54T/oQXBBkHJe3iuz4xlo718Ggl5TalMQPVLSPwK3um64" crossorigin="anonymous">
+  <link rel="stylesheet" href="/css/style.css" integrity="sha384-z2SKY2YGmInhpP4jL+UTEEc0zlifc/3VqFyqr+mLEvgh6LZ/+4bQ5GdvzRIZg5XS" crossorigin="anonymous">
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to content</a>

--- a/static/login.html
+++ b/static/login.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Login - Nullpad</title>
   <link rel="icon" href="/favicon.svg">
-  <link rel="stylesheet" href="/css/style.css" integrity="sha384-ZmOeqL3wZc4O97qSjoY54T/oQXBBkHJe3iuz4xlo718Ggl5TalMQPVLSPwK3um64" crossorigin="anonymous">
+  <link rel="stylesheet" href="/css/style.css" integrity="sha384-z2SKY2YGmInhpP4jL+UTEEc0zlifc/3VqFyqr+mLEvgh6LZ/+4bQ5GdvzRIZg5XS" crossorigin="anonymous">
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to content</a>

--- a/static/login.html
+++ b/static/login.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Login - Nullpad</title>
   <link rel="icon" href="/favicon.svg">
-  <link rel="stylesheet" href="/css/style.css" integrity="sha384-/TvQok4/FK0trD4rGkJJX7fjbTrsOl/TKa7x8xx1uxiizTBGql/rrKSosJCC+r6g" crossorigin="anonymous">
+  <link rel="stylesheet" href="/css/style.css" integrity="sha384-ZmOeqL3wZc4O97qSjoY54T/oQXBBkHJe3iuz4xlo718Ggl5TalMQPVLSPwK3um64" crossorigin="anonymous">
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to content</a>

--- a/static/view.html
+++ b/static/view.html
@@ -5,12 +5,12 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>View Paste - Nullpad</title>
   <link rel="icon" href="/favicon.svg">
-  <link rel="stylesheet" href="/css/style.css" integrity="sha384-ZmOeqL3wZc4O97qSjoY54T/oQXBBkHJe3iuz4xlo718Ggl5TalMQPVLSPwK3um64" crossorigin="anonymous">
+  <link rel="stylesheet" href="/css/style.css" integrity="sha384-z2SKY2YGmInhpP4jL+UTEEc0zlifc/3VqFyqr+mLEvgh6LZ/+4bQ5GdvzRIZg5XS" crossorigin="anonymous">
   <link rel="stylesheet" href="/css/hljs-dark.min.css" integrity="sha384-oaMLBGEzBOJx3UHwac0cVndtX5fxGQIfnAeFZ35RTgqPcYlbprH9o9PUV/F8Le07" crossorigin="anonymous">
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to content</a>
-  <div class="container container--wide" id="main-content">
+  <div class="container" id="main-content">
     <div class="page-header">
       <h1><a href="/" class="title-link">nullpad</a> <img src="/favicon.svg" alt="" class="title-icon" aria-hidden="true"> <a href="/info.html" class="info-link" title="How it works">!</a></h1>
       <p>Decrypting paste...</p>

--- a/static/view.html
+++ b/static/view.html
@@ -5,12 +5,12 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>View Paste - Nullpad</title>
   <link rel="icon" href="/favicon.svg">
-  <link rel="stylesheet" href="/css/style.css" integrity="sha384-/TvQok4/FK0trD4rGkJJX7fjbTrsOl/TKa7x8xx1uxiizTBGql/rrKSosJCC+r6g" crossorigin="anonymous">
+  <link rel="stylesheet" href="/css/style.css" integrity="sha384-ZmOeqL3wZc4O97qSjoY54T/oQXBBkHJe3iuz4xlo718Ggl5TalMQPVLSPwK3um64" crossorigin="anonymous">
   <link rel="stylesheet" href="/css/hljs-dark.min.css" integrity="sha384-oaMLBGEzBOJx3UHwac0cVndtX5fxGQIfnAeFZ35RTgqPcYlbprH9o9PUV/F8Le07" crossorigin="anonymous">
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to content</a>
-  <div class="container" id="main-content">
+  <div class="container container--wide" id="main-content">
     <div class="page-header">
       <h1><a href="/" class="title-link">nullpad</a> <img src="/favicon.svg" alt="" class="title-icon" aria-hidden="true"> <a href="/info.html" class="info-link" title="How it works">!</a></h1>
       <p>Decrypting paste...</p>


### PR DESCRIPTION
## Summary
- Adds a \`.container--wide\` modifier (max-width 1100px) and applies it to \`view.html\`
- Markdown rendering, tables, and code blocks now have noticeably more horizontal room
- Other pages keep the existing 700px reading width

## Test plan
- [x] Open a paste with wide markdown / code blocks — content uses extra width
- [x] Open / and other pages — layout same
- [x] Mobile viewport (≤768px) — content fits, no horizontal scroll