### PR TITLE
fix(auth): await clearSession before logout redirect

### DIFF
--- a/protected/js/admin.js
+++ b/protected/js/admin.js
@@ -392,8 +392,8 @@
   // Logout
   // ============================================================================
 
-  function handleLogout() {
-    NullpadAuth.clearSession();
+  async function handleLogout() {
+    await NullpadAuth.clearSession();
     window.location.href = '/';
   }
 

--- a/protected/js/trusted.js
+++ b/protected/js/trusted.js
@@ -39,8 +39,8 @@
   // Logout
   // ============================================================================
 
-  function handleLogout() {
-    NullpadAuth.clearSession();
+  async function handleLogout() {
+    await NullpadAuth.clearSession();
     window.location.href = '/';
   }
 


### PR DESCRIPTION
## Summary
- The logout button on `admin.html` and `trusted.html` did not actually log the user out: `handleLogout` called the async `NullpadAuth.clearSession()` without awaiting, then immediately set `window.location.href`. The redirect cancelled the in-flight `POST /api/auth/logout` and skipped the `sessionStorage` cleanup that runs after the awaited fetch — leaving the session intact on both client and server.
- Make `handleLogout` async and `await NullpadAuth.clearSession()` in both files before navigating.

## Test plan
- [x] Reviewed by code-reviewer, simplifier, silent-failure-hunter, security/style, spec-compliance subagents
- [x] \`cargo test --lib\` (no Rust changes; format clean)
- [x] \`bash tools/verify-vendor.sh\` passes
- [x] Docker build green
- [x] Manual: log in as trusted user → click Logout → re-visit /trusted.html → expect redirect to /login.html (session cleared)
- [x] Manual: same for admin

## Follow-ups
Filed for separate work:
- Same unawaited pattern in admin.js apiRequest 401 handler
- clearSession silently swallows non-2xx server responses