### PR TITLE
feat(onion): ONION_MODE config to drop Secure cookie flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,3 +39,11 @@ MAX_SESSIONS_PER_USER=5
 
 # Per-user paste limit (0 = unlimited)
 MAX_PASTES_PER_USER=50
+
+# Tor / onion deployment toggle (default false).
+# When true, the Secure flag is omitted from the session cookie. Tor provides
+# end-to-end transport encryption to the hidden service, and browsers silently
+# discard Secure cookies over plain HTTP (which is how a .onion address is
+# reached inside the Tor network). DO NOT enable on clearnet deployments —
+# the Secure flag protects clearnet users from MITM cookie theft.
+ONION_MODE=false

--- a/src/config.rs
+++ b/src/config.rs
@@ -42,6 +42,13 @@ pub struct Config {
 
     // Paste storage
     pub paste_storage_path: std::path::PathBuf,
+
+    // Tor / onion deployment: when true, omit the Secure flag on the session
+    // cookie. Tor transport already provides encryption end-to-end to the
+    // hidden service, and browsers silently discard Secure cookies over plain
+    // HTTP (how an onion address is reached inside Tor). Do NOT enable on
+    // clearnet deployments — Secure protects against MITM cookie theft there.
+    pub onion_mode: bool,
 }
 
 impl std::fmt::Debug for Config {
@@ -66,6 +73,7 @@ impl std::fmt::Debug for Config {
             .field("max_sessions_per_user", &self.max_sessions_per_user)
             .field("max_pastes_per_user", &self.max_pastes_per_user)
             .field("paste_storage_path", &self.paste_storage_path)
+            .field("onion_mode", &self.onion_mode)
             .finish()
     }
 }
@@ -193,6 +201,21 @@ impl Config {
             .map(std::path::PathBuf::from)
             .unwrap_or_else(|_| std::path::PathBuf::from("/data/pastes"));
 
+        // Onion mode: Tor hidden-service deployment toggle
+        let onion_mode = match env::var("ONION_MODE") {
+            Ok(v) => match v.to_ascii_lowercase().as_str() {
+                "true" | "1" | "yes" | "on" => true,
+                "false" | "0" | "no" | "off" | "" => false,
+                _ => {
+                    return Err(ConfigError::InvalidValue(
+                        "ONION_MODE".to_string(),
+                        format!("expected true/false (got {:?})", v),
+                    ));
+                }
+            },
+            Err(_) => false,
+        };
+
         Ok(Config {
             admin_pubkey,
             admin_alias,
@@ -213,7 +236,39 @@ impl Config {
             max_sessions_per_user,
             max_pastes_per_user,
             paste_storage_path,
+            onion_mode,
         })
+    }
+}
+
+impl Config {
+    /// Minimal Config for use in tests. Override individual fields as needed:
+    /// `Config { rate_limit_auth_per_min: 1, ..Config::test_default() }`.
+    /// Public so integration tests in `tests/` can use it.
+    #[doc(hidden)]
+    pub fn test_default() -> Self {
+        Config {
+            admin_pubkey: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=".to_string(),
+            admin_alias: "admin".to_string(),
+            redis_url: "redis://127.0.0.1:6379".to_string(),
+            bind_addr: "127.0.0.1:0".parse().unwrap(),
+            max_upload_bytes: 52_428_800,
+            default_ttl_secs: 86_400,
+            max_ttl_secs: 604_800,
+            invite_ttl_secs: 43_200,
+            user_idle_ttl_secs: 172_800,
+            user_active_ttl_secs: 86_400,
+            session_ttl_secs: 900,
+            challenge_ttl_secs: 30,
+            rate_limit_paste_per_min: 10_000,
+            rate_limit_auth_per_min: 10_000,
+            rate_limit_pin_attempt: 10_000,
+            trusted_proxy_count: 0,
+            max_sessions_per_user: 5,
+            max_pastes_per_user: 50,
+            paste_storage_path: std::path::PathBuf::from("/tmp/nullpad-test"),
+            onion_mode: false,
+        }
     }
 }
 
@@ -264,6 +319,7 @@ mod tests {
         env::remove_var("MAX_SESSIONS_PER_USER");
         env::remove_var("MAX_PASTES_PER_USER");
         env::remove_var("PASTE_STORAGE_PATH");
+        env::remove_var("ONION_MODE");
     }
 
     #[test]
@@ -523,6 +579,53 @@ mod tests {
             config.paste_storage_path,
             std::path::PathBuf::from("/data/pastes")
         );
+        assert!(!config.onion_mode);
+        clear_test_env();
+    }
+
+    #[test]
+    fn test_onion_mode_parses_truthy_values() {
+        let _guard = lock_test();
+        clear_test_env();
+
+        env::set_var("ADMIN_PUBKEY", TEST_PUBKEY_B64);
+        env::set_var("REDIS_URL", "redis://127.0.0.1:6379");
+
+        for v in ["true", "1", "yes", "on", "TRUE", "True"] {
+            env::set_var("ONION_MODE", v);
+            let config = Config::from_env().unwrap();
+            assert!(config.onion_mode, "value {:?} should enable onion_mode", v);
+        }
+
+        for v in ["false", "0", "no", "off", "", "False"] {
+            env::set_var("ONION_MODE", v);
+            let config = Config::from_env().unwrap();
+            assert!(
+                !config.onion_mode,
+                "value {:?} should disable onion_mode",
+                v
+            );
+        }
+
+        clear_test_env();
+    }
+
+    #[test]
+    fn test_onion_mode_invalid_value_errors() {
+        let _guard = lock_test();
+        clear_test_env();
+
+        env::set_var("ADMIN_PUBKEY", TEST_PUBKEY_B64);
+        env::set_var("REDIS_URL", "redis://127.0.0.1:6379");
+        env::set_var("ONION_MODE", "maybe");
+
+        let result = Config::from_env();
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            ConfigError::InvalidValue(ref s, _) if s == "ONION_MODE"
+        ));
+
         clear_test_env();
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -159,6 +159,12 @@ async fn main() {
     let config = Config::from_env().expect("Failed to load config");
     tracing::info!("Starting nullpad on {}", config.bind_addr);
 
+    if config.onion_mode {
+        tracing::warn!(
+            "onion mode active: Secure cookie flag disabled; assumes Tor transport provides encryption"
+        );
+    }
+
     // Initialize paste storage directory
     storage::blob::init_storage(&config.paste_storage_path)
         .await

--- a/src/routes/auth.rs
+++ b/src/routes/auth.rs
@@ -18,6 +18,23 @@ use axum::{
 use base64::{engine::general_purpose, Engine as _};
 use std::net::SocketAddr;
 
+/// Compute the `Secure` cookie attribute fragment for the session cookie.
+///
+/// Returns `"; Secure"` when the transport is HTTPS and onion_mode is disabled.
+/// In onion_mode, omit `Secure` unconditionally: Tor provides transport encryption,
+/// and browsers silently discard `Secure` cookies over plain HTTP, which is how a
+/// hidden service is reached from inside the Tor network. Do NOT use onion_mode
+/// on clearnet deployments.
+fn secure_cookie_attr(headers: &HeaderMap, config: &crate::config::Config) -> &'static str {
+    if config.onion_mode {
+        ""
+    } else if is_https(headers, config.trusted_proxy_count) {
+        "; Secure"
+    } else {
+        ""
+    }
+}
+
 /// Check if the incoming request arrived over HTTPS.
 ///
 /// Only trusts `X-Forwarded-Proto` / `Forwarded` headers when `trusted_proxy_count > 0`
@@ -173,11 +190,7 @@ pub async fn verify_challenge(
     // Set HttpOnly session cookie for browser navigation to protected pages.
     // The same token is returned in JSON for JS to store in sessionStorage (API calls).
     let role_str = user.role.to_string();
-    let secure = if is_https(&headers, state.config.trusted_proxy_count) {
-        "; Secure"
-    } else {
-        ""
-    };
+    let secure = secure_cookie_attr(&headers, &state.config);
     let cookie = format!(
         "np_session={}; HttpOnly; SameSite=Strict{}; Path=/; Max-Age={}",
         token, secure, state.config.session_ttl_secs
@@ -294,11 +307,7 @@ pub async fn logout(
     tracing::info!(action = "logout", user_id = %session.user_id, "User logged out");
 
     // Clear the session cookie on logout.
-    let secure = if is_https(&headers, state.config.trusted_proxy_count) {
-        "; Secure"
-    } else {
-        ""
-    };
+    let secure = secure_cookie_attr(&headers, &state.config);
     let clear_cookie = format!(
         "np_session=; HttpOnly; SameSite=Strict{}; Path=/; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT",
         secure
@@ -308,4 +317,49 @@ pub async fn logout(
         StatusCode::NO_CONTENT,
         [(axum::http::header::SET_COOKIE, clear_cookie)],
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Config;
+
+    fn test_config(onion_mode: bool, trusted_proxy_count: usize) -> Config {
+        Config {
+            onion_mode,
+            trusted_proxy_count,
+            ..Config::test_default()
+        }
+    }
+
+    fn https_headers() -> HeaderMap {
+        let mut h = HeaderMap::new();
+        h.insert("x-forwarded-proto", "https".parse().unwrap());
+        h
+    }
+
+    #[test]
+    fn secure_cookie_attr_https_no_onion_sets_secure() {
+        let cfg = test_config(false, 1);
+        assert_eq!(secure_cookie_attr(&https_headers(), &cfg), "; Secure");
+    }
+
+    #[test]
+    fn secure_cookie_attr_http_no_onion_no_secure() {
+        let cfg = test_config(false, 0);
+        assert_eq!(secure_cookie_attr(&HeaderMap::new(), &cfg), "");
+    }
+
+    #[test]
+    fn secure_cookie_attr_onion_mode_omits_secure_even_when_https() {
+        let cfg = test_config(true, 1);
+        // Even with X-Forwarded-Proto: https from a trusted proxy, onion_mode wins.
+        assert_eq!(secure_cookie_attr(&https_headers(), &cfg), "");
+    }
+
+    #[test]
+    fn secure_cookie_attr_onion_mode_omits_secure_on_http() {
+        let cfg = test_config(true, 0);
+        assert_eq!(secure_cookie_attr(&HeaderMap::new(), &cfg), "");
+    }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -193,22 +193,9 @@ async fn spawn_test_server_with_auth_limit(
         admin_pubkey,
         admin_alias: admin_alias.clone(),
         redis_url: test_redis_url.clone(),
-        bind_addr: "127.0.0.1:0".parse().unwrap(),
-        max_upload_bytes: 52_428_800,
-        default_ttl_secs: 86400,
-        max_ttl_secs: 604800,
-        invite_ttl_secs: 43200,
-        user_idle_ttl_secs: 172800,
-        user_active_ttl_secs: 86400,
-        session_ttl_secs: 900,
-        challenge_ttl_secs: 30,
-        rate_limit_paste_per_min: 10000,
         rate_limit_auth_per_min: limit,
-        rate_limit_pin_attempt: 10000,
-        trusted_proxy_count: 0,
-        max_sessions_per_user: 5,
-        max_pastes_per_user: 50,
         paste_storage_path,
+        ..Config::test_default()
     };
 
     let state = AppState {
@@ -269,22 +256,9 @@ async fn spawn_test_server_with_pin_limit(
         admin_pubkey,
         admin_alias: admin_alias.clone(),
         redis_url: test_redis_url.clone(),
-        bind_addr: "127.0.0.1:0".parse().unwrap(),
-        max_upload_bytes: 52_428_800,
-        default_ttl_secs: 86400,
-        max_ttl_secs: 604800,
-        invite_ttl_secs: 43200,
-        user_idle_ttl_secs: 172800,
-        user_active_ttl_secs: 86400,
-        session_ttl_secs: 900,
-        challenge_ttl_secs: 30,
-        rate_limit_paste_per_min: 10000,
-        rate_limit_auth_per_min: 10000,
         rate_limit_pin_attempt: limit,
-        trusted_proxy_count: 0,
-        max_sessions_per_user: 5,
-        max_pastes_per_user: 50,
         paste_storage_path,
+        ..Config::test_default()
     };
 
     let state = AppState {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -128,6 +128,8 @@ async fn main() {
         test_protected_html_with_session_cookie,
         test_protected_html_not_served_by_static_fallback,
         test_verify_sets_np_session_cookie,
+        test_clearnet_https_sets_secure_cookie,
+        test_onion_mode_omits_secure_cookie,
     ];
 
     // Explicitly remove the container (ContainerAsync has no Drop cleanup).
@@ -194,6 +196,73 @@ async fn spawn_test_server_with_auth_limit(
         admin_alias: admin_alias.clone(),
         redis_url: test_redis_url.clone(),
         rate_limit_auth_per_min: limit,
+        paste_storage_path,
+        ..Config::test_default()
+    };
+
+    let state = AppState {
+        redis: redis_manager,
+        config: Arc::new(config),
+        ip_hmac_salt: Arc::new(rand::random()),
+    };
+
+    let app = routes::api_router()
+        .fallback_service(ServeDir::new("static"))
+        .layer(axum::middleware::from_fn(security_headers))
+        .with_state(state);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("Failed to bind");
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+        )
+        .await
+        .unwrap();
+    });
+
+    let base_url = format!("http://{}", addr);
+    (base_url, con, admin_key, admin_alias)
+}
+
+/// Spin up a test server with onion_mode + trusted_proxy_count overrides.
+/// Used to exercise the Secure cookie attribute logic under both Tor (onion_mode=true)
+/// and clearnet-HTTPS-behind-proxy (onion_mode=false, trusted_proxy_count=1) shapes.
+async fn spawn_test_server_with_cookie_config(
+    onion_mode: bool,
+    trusted_proxy_count: usize,
+) -> (String, redis::aio::ConnectionManager, SigningKey, String) {
+    let (admin_key, admin_pubkey) = test_keypair();
+    let admin_alias = format!("testadmin_{}", nanoid::nanoid!(6));
+
+    let test_redis_url = get_redis_url().to_string();
+    let redis_client = redis::Client::open(test_redis_url.as_str()).expect("Failed to open Redis");
+    let redis_manager = redis_client
+        .get_connection_manager()
+        .await
+        .expect("Failed to get connection manager");
+    let mut con = redis_manager.clone();
+
+    nullpad::storage::user::upsert_admin(&mut con, &admin_pubkey, &admin_alias)
+        .await
+        .expect("Failed to upsert admin");
+
+    let paste_storage_path =
+        std::env::temp_dir().join(format!("nullpad_test_{}", nanoid::nanoid!(8)));
+    nullpad::storage::blob::init_storage(&paste_storage_path)
+        .await
+        .expect("Failed to init paste storage");
+
+    let config = Config {
+        admin_pubkey,
+        admin_alias: admin_alias.clone(),
+        redis_url: test_redis_url.clone(),
+        onion_mode,
+        trusted_proxy_count,
         paste_storage_path,
         ..Config::test_default()
     };
@@ -2457,5 +2526,85 @@ async fn test_verify_sets_np_session_cookie() {
     assert!(
         cookie.contains("SameSite=Strict"),
         "cookie should be SameSite=Strict"
+    );
+}
+
+/// Drive a verify flow against the given base URL, returning the Set-Cookie header.
+/// Optionally sets X-Forwarded-Proto: https to simulate a trusted reverse proxy.
+async fn fetch_verify_set_cookie(
+    base_url: &str,
+    alias: &str,
+    signing_key: &SigningKey,
+    forwarded_proto_https: bool,
+) -> String {
+    let client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap();
+
+    let resp = client
+        .post(format!("{}/api/auth/challenge", base_url))
+        .json(&serde_json::json!({"alias": alias}))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    let nonce_b64 = body["nonce"].as_str().unwrap();
+
+    let nonce_bytes = general_purpose::STANDARD.decode(nonce_b64).unwrap();
+    let signature = signing_key.sign(&nonce_bytes);
+    let sig_b64 = general_purpose::STANDARD.encode(signature.to_bytes());
+
+    let mut req = client
+        .post(format!("{}/api/auth/verify", base_url))
+        .json(&serde_json::json!({"alias": alias, "signature": sig_b64}));
+    if forwarded_proto_https {
+        req = req.header("x-forwarded-proto", "https");
+    }
+    let resp = req.send().await.unwrap();
+    assert_eq!(resp.status(), 200);
+
+    resp.headers()
+        .get("set-cookie")
+        .expect("verify response must set np_session cookie")
+        .to_str()
+        .unwrap()
+        .to_string()
+}
+
+/// Baseline for the next test: with onion_mode=false, a trusted proxy forwarding
+/// X-Forwarded-Proto: https causes Secure to be set. Confirms our HTTPS detection
+/// works so the onion_mode=true test below is actually testing onion_mode's effect
+/// and not just the HTTP transport.
+async fn test_clearnet_https_sets_secure_cookie() {
+    let (base_url, _con, admin_key, admin_alias) =
+        spawn_test_server_with_cookie_config(false, 1).await;
+    let cookie = fetch_verify_set_cookie(&base_url, &admin_alias, &admin_key, true).await;
+    assert!(
+        cookie.contains("Secure"),
+        "clearnet + X-Forwarded-Proto: https must set Secure (got: {})",
+        cookie
+    );
+}
+
+/// With ONION_MODE=true, the Secure flag must be omitted from Set-Cookie even when
+/// a trusted reverse proxy forwards X-Forwarded-Proto: https. Tor's onion transport
+/// provides encryption; browsers discard Secure cookies over the plain HTTP that the
+/// onion endpoint receives, which would break auth.
+async fn test_onion_mode_omits_secure_cookie() {
+    let (base_url, _con, admin_key, admin_alias) =
+        spawn_test_server_with_cookie_config(true, 1).await;
+    let cookie = fetch_verify_set_cookie(&base_url, &admin_alias, &admin_key, true).await;
+    assert!(
+        !cookie.contains("Secure"),
+        "onion_mode=true must omit Secure attribute (got: {})",
+        cookie
+    );
+    // Other attributes still present.
+    assert!(cookie.contains("HttpOnly"), "HttpOnly must remain set");
+    assert!(
+        cookie.contains("SameSite=Strict"),
+        "SameSite=Strict must remain set"
     );
 }


### PR DESCRIPTION
## Summary
- Adds `onion_mode: bool` to `Config` (env `ONION_MODE`, default false; accepts true/1/yes/on or false/0/no/off/empty, case-insensitive; rejects anything else at startup).
- When enabled, both `Set-Cookie` sites (`/api/auth/verify` and `/api/auth/logout`) omit the `Secure` flag via a new shared helper `secure_cookie_attr`. Tor's onion transport already encrypts end-to-end, and browsers silently discard `Secure` cookies over plain HTTP — which is how a hidden service is reached inside the Tor network.
- Clearnet behavior is unchanged: `Secure` is still set whenever `is_https()` returns true and `onion_mode` is false.
- Startup emits a `warn`-level log when onion mode is active, so operators see the security-degrading switch in any reasonable log level.
- Extracts `Config::test_default()` to consolidate three near-identical Config struct literals (two integration test sites + one new unit test); future fields are now a single-site update.

## Test plan
- [x] Reviewed by code-reviewer, simplifier, silent-failure-hunter, security/style, spec-compliance, zero-knowledge-auditor subagents
- [x] \`cargo fmt --check && cargo clippy -- -D warnings\` clean
- [x] \`cargo test --lib\` (72 passed)
- [x] \`cargo test --test integration -- --test-threads=1\` (44 passed)
- [x] Docker build green
- [ ] Manual onion deploy verification once the docker-compose.onion.yml override lands