### PR TITLE
feat(crypto): frame plaintext with version byte + length prefix

### DIFF
--- a/protected/trusted.html
+++ b/protected/trusted.html
@@ -109,7 +109,7 @@
   <script src="/js/vendor/argon2.umd.min.js" integrity="sha384-tP0Wy54CKmng7i9EoTlPySD0hBx6Octj0VS6MfwlnUu111MPa+JLm0CCbep6XJ1W" crossorigin="anonymous"></script>
   <script src="/js/base64.js" integrity="sha384-dPTAiUm9yBw/r5Adl39R/YFMjDuMdHLZzDlXUciVyVhDdowN5rilt9FSG8+ca8Z5" crossorigin="anonymous"></script>
   <script src="/js/utils.js" integrity="sha384-9aI3LLqvhcIML5spCFHeYp0zQSUziCRpLzVROi814pG+uJL/YKENKlTkCR/6bqV6" crossorigin="anonymous"></script>
-  <script src="/js/crypto.js" integrity="sha384-PfofPCMaREa8BBBuVaKzG7yYvBzSgpaudQNWqdEJv1Aw3I3awjMSORDuvRF3c8+N" crossorigin="anonymous"></script>
+  <script src="/js/crypto.js" integrity="sha384-tX5SGkFKYOlDjEhntZ6UPQ8KVlrnajgJX/Z3+XI+NCTR4HXffcHvhjxkeaUPgTB7" crossorigin="anonymous"></script>
   <script src="/js/auth.js" integrity="sha384-nO5uz/Sdf8MxdDYah9a6DTEYrerBtkEwRzF8NZOj4z/3XCN+U1cGFKc07NanAY7Z" crossorigin="anonymous"></script>
   <script src="/js/create.js" integrity="sha384-HJsDqsctVgDivmcRY5lDt9taM9thJ9ZoRWGbU7xFPB0AbfV5Mwi+KpXYLU1+q+Y4" crossorigin="anonymous"></script>
   <script src="/js/trusted-loader.js" integrity="sha384-XNfscS8RDNh1pw4Wh9hpNrGzrhJXeLtW87SqaxKVBVub0RgZ/FbAZSv+CGdq6fMs" crossorigin="anonymous"></script>

--- a/static/index.html
+++ b/static/index.html
@@ -94,7 +94,7 @@
   <script src="/js/vendor/argon2.umd.min.js" integrity="sha384-tP0Wy54CKmng7i9EoTlPySD0hBx6Octj0VS6MfwlnUu111MPa+JLm0CCbep6XJ1W" crossorigin="anonymous"></script>
   <script src="/js/base64.js" integrity="sha384-dPTAiUm9yBw/r5Adl39R/YFMjDuMdHLZzDlXUciVyVhDdowN5rilt9FSG8+ca8Z5" crossorigin="anonymous"></script>
   <script src="/js/utils.js" integrity="sha384-9aI3LLqvhcIML5spCFHeYp0zQSUziCRpLzVROi814pG+uJL/YKENKlTkCR/6bqV6" crossorigin="anonymous"></script>
-  <script src="/js/crypto.js" integrity="sha384-PfofPCMaREa8BBBuVaKzG7yYvBzSgpaudQNWqdEJv1Aw3I3awjMSORDuvRF3c8+N" crossorigin="anonymous"></script>
+  <script src="/js/crypto.js" integrity="sha384-tX5SGkFKYOlDjEhntZ6UPQ8KVlrnajgJX/Z3+XI+NCTR4HXffcHvhjxkeaUPgTB7" crossorigin="anonymous"></script>
   <script src="/js/create.js" integrity="sha384-HJsDqsctVgDivmcRY5lDt9taM9thJ9ZoRWGbU7xFPB0AbfV5Mwi+KpXYLU1+q+Y4" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/static/js/crypto.js
+++ b/static/js/crypto.js
@@ -124,6 +124,62 @@
     }
 
     // ============================================================================
+    // Plaintext Framing
+    // ============================================================================
+    //
+    // Inside the AES-GCM ciphertext, plaintext is framed as:
+    //   [version: 1 byte (0x01)] [length: 4 bytes LE] [data: <length> bytes] [padding: trailing bytes ignored]
+    //
+    // The version byte lets future formats add padding (forthcoming bucket
+    // ladder) without breaking existing pastes. The length prefix is what
+    // tells the decoder where real data ends so padding can be stripped.
+    //
+    // Backward compatibility: pastes encrypted before this change have no
+    // version byte. On decrypt, a first byte != VERSION_V1 (or a malformed
+    // V1 header) is treated as legacy v0 and returned unchanged.
+
+    const VERSION_V1 = 0x01;
+    const V1_HEADER_LEN = 5; // 1 byte version + 4 bytes length
+
+    /** Wrap raw plaintext bytes in the V1 frame: [0x01][length LE u32][data]. */
+    function frameV1(plaintextBytes) {
+        const out = new Uint8Array(V1_HEADER_LEN + plaintextBytes.length);
+        out[0] = VERSION_V1;
+        // 4-byte little-endian length prefix
+        new DataView(out.buffer).setUint32(1, plaintextBytes.length, true);
+        out.set(plaintextBytes, V1_HEADER_LEN);
+        return out;
+    }
+
+    /**
+     * Strip the V1 frame if present and well-formed. Returns null otherwise so
+     * the caller can fall back to the legacy v0 path (return bytes as-is).
+     *
+     * A legacy v0 plaintext whose first byte happens to be 0x01 followed by a
+     * 4-byte run that decodes to a length > body would mistakenly enter this
+     * function. By returning null on that mismatch rather than throwing, we
+     * keep legacy binary pastes (e.g. files starting with 0x01) decryptable
+     * instead of surfacing as the generic "Invalid key or PIN" error that the
+     * decrypt-retry chain in view.js would otherwise remap a throw into.
+     * The residual collision case — first byte 0x01 AND a 4-byte length value
+     * that happens to be <= body — silently truncates the legacy plaintext;
+     * this is the unavoidable migration cost of an in-band version sniff and
+     * affects only pre-existing binary pastes.
+     */
+    function unframeV1OrNull(decryptedBytes) {
+        if (decryptedBytes.length < V1_HEADER_LEN) return null;
+        if (decryptedBytes[0] !== VERSION_V1) return null;
+        const length = new DataView(
+            decryptedBytes.buffer,
+            decryptedBytes.byteOffset + 1,
+            4
+        ).getUint32(0, true);
+        const bodyLen = decryptedBytes.length - V1_HEADER_LEN;
+        if (length > bodyLen) return null;
+        return decryptedBytes.subarray(V1_HEADER_LEN, V1_HEADER_LEN + length);
+    }
+
+    // ============================================================================
     // Encryption
     // ============================================================================
 
@@ -139,6 +195,10 @@
         const plaintextBytes = typeof plaintext === 'string'
             ? textEncode(plaintext)
             : plaintext;
+
+        // Frame with version byte + length prefix before encryption so the
+        // decoder can strip future padding back to the real data length.
+        const framedBytes = frameV1(plaintextBytes);
 
         // Decode key
         const keyBytes = base64urlDecode(keyBase64url);
@@ -167,7 +227,7 @@
             const ciphertext = await crypto.subtle.encrypt(
                 params,
                 cryptoKey,
-                plaintextBytes
+                framedBytes
             );
 
             // Concatenate IV + ciphertext
@@ -228,7 +288,10 @@
                 ciphertext
             );
 
-            return new Uint8Array(plaintext);
+            const decryptedBytes = new Uint8Array(plaintext);
+            // Strip V1 frame ([0x01][len LE u32][data]) when present. Legacy
+            // (pre-frame) pastes lack the version byte and are returned as-is.
+            return unframeV1OrNull(decryptedBytes) ?? decryptedBytes;
         } finally {
             keyBytes.fill(0);
         }

--- a/static/view.html
+++ b/static/view.html
@@ -91,7 +91,7 @@
   <script src="/js/vendor/argon2.umd.min.js" integrity="sha384-tP0Wy54CKmng7i9EoTlPySD0hBx6Octj0VS6MfwlnUu111MPa+JLm0CCbep6XJ1W" crossorigin="anonymous"></script>
   <script src="/js/base64.js" integrity="sha384-dPTAiUm9yBw/r5Adl39R/YFMjDuMdHLZzDlXUciVyVhDdowN5rilt9FSG8+ca8Z5" crossorigin="anonymous"></script>
   <script src="/js/utils.js" integrity="sha384-9aI3LLqvhcIML5spCFHeYp0zQSUziCRpLzVROi814pG+uJL/YKENKlTkCR/6bqV6" crossorigin="anonymous"></script>
-  <script src="/js/crypto.js" integrity="sha384-PfofPCMaREa8BBBuVaKzG7yYvBzSgpaudQNWqdEJv1Aw3I3awjMSORDuvRF3c8+N" crossorigin="anonymous"></script>
+  <script src="/js/crypto.js" integrity="sha384-tX5SGkFKYOlDjEhntZ6UPQ8KVlrnajgJX/Z3+XI+NCTR4HXffcHvhjxkeaUPgTB7" crossorigin="anonymous"></script>
   <script src="/js/view.js" integrity="sha384-Sp0epC2vXtXXpfEcqRNt7lbLZaU/ngn9s354PRmfGxUBy1U0pjgSl1C++aYzSQ1p" crossorigin="anonymous"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
Wraps plaintext inside the AES-GCM ciphertext in a forward-compatible frame so a future change can add a padding bucket ladder without breaking existing pastes:

\`\`\`
[version: 1 byte (0x01)] [length: u32 LE] [data: <length> bytes]
\`\`\`

- \`encrypt()\` now frames before encryption.
- \`decrypt()\` strips the frame after decryption, with backward compat for pre-frame pastes (returns bytes as-is when the first byte is not \`0x01\` or when the embedded length exceeds the body).
- The framing layer never throws on header mismatch — returns null and the caller falls back. This deliberately avoids tripping view.js's decrypt-retry chain, which would otherwise surface a misleading "Invalid key or PIN" for legacy binary pastes starting with \`0x01\`.
- Documented residual collision: a legacy plaintext starting with \`[0x01, ..LE length <= body, ...]\` would silently truncate. Unavoidable cost of in-band version sniffing; only affects pre-existing binary pastes.

SRI hashes refreshed for the 3 HTML files referencing \`crypto.js\`.

## Test plan
- [x] Reviewed by code-reviewer, simplifier, silent-failure-hunter, security/style, spec-compliance, zero-knowledge-auditor subagents
- [x] Node.js harness using native Web Crypto verified 7 scenarios: text/AAD/empty/binary round-trip, legacy v0 passthrough, legacy with 0x01-prefix-but-invalid-length passthrough, and the documented collision case
- [x] \`bash tools/verify-vendor.sh\` passes (SRI integrity)
- [x] \`cargo fmt --check && cargo test --lib && cargo test --test integration -- --test-threads=1\` clean (server-side unaffected)
- [x] Manual: create a new text paste → view it (frame round-trip)
- [x] Manual: load a paste created before this change (legacy v0 still decrypts)

## Follow-ups
- nullpad-0n7: view.js bare catches that swallow framing/decrypt errors as the generic "Invalid key or PIN" message (pre-existing, unblocked by this work)