### PR TITLE
fix(view): surface decrypt errors instead of swallowing them

### DIFF
--- a/static/js/view.js
+++ b/static/js/view.js
@@ -221,18 +221,23 @@
           const fileMeta = JSON.parse(new TextDecoder().decode(metaBytes));
           if (typeof fileMeta.filename === 'string') metadata.filename = fileMeta.filename;
           if (typeof fileMeta.content_type === 'string') metadata.mimetype = fileMeta.content_type;
-        } catch {
-          // Fallback to server-provided plaintext metadata (legacy pastes)
+        } catch (err) {
+          // Intentional fallback to server-provided plaintext metadata for legacy
+          // pastes. Logged so unexpected failures (e.g. corruption, wrong key) are
+          // visible in devtools instead of silently masquerading as a legacy paste.
+          console.warn('Encrypted-metadata decrypt failed; using server-provided metadata:', err);
         }
       }
 
-      // Try decryption with paste ID as AAD first (new format),
-      // fall back to without AAD (backward compat for old pastes)
+      // Try decryption with paste ID as AAD first (new format), fall back to
+      // without AAD only on auth-tag mismatch (OperationError) — that's the
+      // genuine legacy compat case. Other error classes (TypeError, framing
+      // errors) propagate so they reach the outer catch's console.error.
       let bytes;
       try {
         bytes = await NullpadCrypto.decrypt(encryptedData, decryptionKey, pasteId);
-      } catch {
-        // Fallback to non-AAD decryption (backward compat for old pastes)
+      } catch (err) {
+        if (err.name !== 'OperationError') throw err;
         bytes = await NullpadCrypto.decrypt(encryptedData, decryptionKey);
       }
 
@@ -247,6 +252,9 @@
         return { type: 'binary', content: null, bytes: bytes };
       }
     } catch (err) {
+      // Surface the real error in devtools but keep the user-facing message
+      // generic to avoid leaking decryption-state details to bystanders.
+      console.error('Paste decryption failed:', err);
       throw new Error('Decryption failed. Invalid key or PIN.');
     }
   }

--- a/static/view.html
+++ b/static/view.html
@@ -92,6 +92,6 @@
   <script src="/js/base64.js" integrity="sha384-dPTAiUm9yBw/r5Adl39R/YFMjDuMdHLZzDlXUciVyVhDdowN5rilt9FSG8+ca8Z5" crossorigin="anonymous"></script>
   <script src="/js/utils.js" integrity="sha384-9aI3LLqvhcIML5spCFHeYp0zQSUziCRpLzVROi814pG+uJL/YKENKlTkCR/6bqV6" crossorigin="anonymous"></script>
   <script src="/js/crypto.js" integrity="sha384-tX5SGkFKYOlDjEhntZ6UPQ8KVlrnajgJX/Z3+XI+NCTR4HXffcHvhjxkeaUPgTB7" crossorigin="anonymous"></script>
-  <script src="/js/view.js" integrity="sha384-Sp0epC2vXtXXpfEcqRNt7lbLZaU/ngn9s354PRmfGxUBy1U0pjgSl1C++aYzSQ1p" crossorigin="anonymous"></script>
+  <script src="/js/view.js" integrity="sha384-uVj6eQocqP5eqBdIE8hH4LI0Kxoqv6kDHH7UAarvKJ75muaF1pDnAYWOZk+geNgv" crossorigin="anonymous"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
\`decryptPaste\` in \`static/js/view.js\` had three silent-failure spots that funnelled every internal failure into the generic user-facing \"Invalid key or PIN\":

- **encrypted_metadata decrypt** — bare \`catch {}\` fell back to server-provided plaintext metadata for legacy pastes, masking actual corruption.
- **AAD decrypt retry** — bare \`catch {}\` fell back to the non-AAD legacy path on ANY error class. Any future framing/DataError-class error would be remapped into the wrong branch.
- **Outer catch (err)** discarded \`err\` entirely, so a developer in devtools couldn't see the underlying cause.

Fixes:
- metadata catch logs via \`console.warn\` (intentional fallback preserved, but now observable),
- AAD-retry catch narrows to \`OperationError\` (the only legitimate GCM auth-tag-mismatch case) and rethrows others,
- outer catch \`console.error\`'s \`err\` before re-throwing the generic user-facing message (preserved intentionally to avoid leaking crypto state to onlookers).

SRI hash refreshed for \`view.js\`.

## Test plan
- [x] Reviewed by code-reviewer, silent-failure-hunter, security/style, zero-knowledge-auditor subagents (all PASS)
- [x] \`cargo fmt --check && cargo test --lib\` clean (no Rust changes)
- [x] \`bash tools/verify-vendor.sh\` passes (SRI integrity)
- [x] Manual: open a paste with a wrong key → expect devtools \`console.error\` plus user-facing generic message
- [x] Manual: open a legacy non-AAD paste with correct key → expect AAD-retry → no-AAD path → successful decrypt (no console output)