### PR TITLE
docs: clarify Mermaid/flowcharts intentionally unsupported

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,12 @@ Rate limiting, session lifetimes, and challenge timeouts are also configurable. 
 - marked.js + highlight.js for markdown rendering
 - DOMPurify for XSS-safe HTML sanitization
 
+> **Note:** Mermaid/flowchart diagrams are intentionally **not** supported. A
+> `mermaid` code block renders as plain syntax-highlighted text, not a diagram.
+> Mermaid would require loosening the strict CSP (`style-src` inline styles) and
+> allowlisting a large SVG surface in DOMPurify, which conflicts with the
+> zero-knowledge/strict-CSP security posture.
+
 ## API Endpoints
 
 ### Public


### PR DESCRIPTION
## What

Adds a note to the README's Frontend section explaining that Mermaid/flowchart diagrams are **intentionally not supported**. A ```mermaid``` code block renders as plain syntax-highlighted text, not a diagram.

## Why

Reported as "flowcharts in markdown don't work." Mermaid was never wired into the renderer (`view.js` runs marked → DOMPurify → highlight.js only). Adding it would require:

- Loosening the strict CSP (`style-src` inline styles Mermaid injects)
- Allowlisting a large SVG tag/attr surface in the DOMPurify config

Both conflict with the zero-knowledge / strict-CSP security posture, so the decision is to leave it unsupported and document it so it isn't re-filed as a bug.

Documentation-only change — no code touched.