### PR TITLE
fix: treat Ed25519 pubkeys as confidential (alias-as-salt offline cracking)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ cargo run --release
 
 See `.env.example` for all available options. Key environment variables:
 
-- `ADMIN_PUBKEY` — Base64-encoded Ed25519 public key (32 bytes), generated via `cargo run -- keygen` (required)
+- `ADMIN_PUBKEY` — Base64-encoded Ed25519 public key (32 bytes), generated via `cargo run -- keygen` (required). **Keep this confidential** — treat it like a password hash. Because the Ed25519 keypair is derived deterministically from `Argon2id(secret, salt=alias)`, anyone who obtains the public key can run an offline dictionary attack against the secret with no rate limiting.
 - `ADMIN_ALIAS` — Admin username (default: "admin")
 - `REDIS_URL` — Redis connection string (default: "redis://127.0.0.1:6379")
 - `BIND_ADDR` — Server bind address (default: "0.0.0.0:3000")
@@ -108,6 +108,12 @@ Rate limiting, session lifetimes, and challenge timeouts are also configurable. 
 - Session tokens expire in 15 minutes
 - Auth challenge returns identical responses for valid and invalid aliases (anti-enumeration)
 - ADMIN_PUBKEY validated as correct Ed25519 key at startup (fail-fast)
+
+**Keypair Derivation & Secret Policy**
+
+- Ed25519 keypairs are derived deterministically: `Argon2id(secret, salt=alias)` — portability tradeoff (no server-stored salt)
+- Consequence: Ed25519 public keys are **confidential**. Anyone holding a public key can attempt an offline dictionary attack against the secret (no rate limit applies). Public keys are therefore never returned by the API.
+- Use a **strong, unique secret of at least 12 characters**. The Argon2id params (m=19456, t=2, p=1) raise the cost per guess, but a weak or short secret remains vulnerable to offline cracking.
 
 **Transport & Headers**
 

--- a/protected/admin.html
+++ b/protected/admin.html
@@ -83,13 +83,12 @@
             <tr>
               <th scope="col">Alias</th>
               <th scope="col">User ID</th>
-              <th scope="col">Public Key</th>
               <th scope="col">Actions</th>
             </tr>
           </thead>
           <tbody id="users-list">
             <tr>
-              <td colspan="4" class="text-center text-muted">Loading users...</td>
+              <td colspan="3" class="text-center text-muted">Loading users...</td>
             </tr>
           </tbody>
         </table>

--- a/protected/js/admin.js
+++ b/protected/js/admin.js
@@ -246,7 +246,7 @@
       if (users.length === 0) {
         const row = document.createElement('tr');
         const cell = document.createElement('td');
-        cell.colSpan = 4;
+        cell.colSpan = 3;
         cell.className = 'text-center text-muted';
         cell.textContent = 'No users found';
         row.appendChild(cell);
@@ -272,15 +272,6 @@
         idCell.appendChild(idCode);
         row.appendChild(idCell);
 
-        // Public key cell
-        const pubkeyCell = document.createElement('td');
-        const pubkeyCode = document.createElement('code');
-        pubkeyCode.className = 'text-muted';
-        pubkeyCode.style.fontSize = '0.75em';
-        pubkeyCode.textContent = user.pubkey ? user.pubkey.substring(0, 32) + '...' : 'N/A';
-        pubkeyCell.appendChild(pubkeyCode);
-        row.appendChild(pubkeyCell);
-
         // Actions cell
         const actionsCell = document.createElement('td');
         if (user.id !== 'admin') {
@@ -303,7 +294,7 @@
       clearElement(usersList);
       const row = document.createElement('tr');
       const cell = document.createElement('td');
-      cell.colSpan = 4;
+      cell.colSpan = 3;
       cell.className = 'text-center text-error';
       cell.textContent = 'Failed to load users';
       row.appendChild(cell);

--- a/src/models.rs
+++ b/src/models.rs
@@ -167,7 +167,6 @@ pub struct InviteInfo {
 pub struct UserInfo {
     pub id: String,
     pub alias: String,
-    pub pubkey: String,
     pub role: String,
     pub created_at: u64,
 }

--- a/src/routes/admin.rs
+++ b/src/routes/admin.rs
@@ -112,13 +112,14 @@ pub async fn list_users(
 
     let users = storage::user::list_users(&mut con).await?;
 
-    // Convert to UserInfo
+    // Convert to UserInfo — pubkey is intentionally excluded: it is brute-force
+    // material because the Ed25519 keypair is derived as Argon2id(secret, salt=alias),
+    // so anyone holding a pubkey can crack the secret fully offline.
     let user_infos: Vec<UserInfo> = users
         .into_iter()
         .map(|user| UserInfo {
             id: user.id,
             alias: user.alias,
-            pubkey: user.pubkey,
             role: user.role.to_string(),
             created_at: user.created_at,
         })

--- a/static/invite.html
+++ b/static/invite.html
@@ -88,6 +88,6 @@
   <script src="/js/vendor/argon2.umd.min.js" integrity="sha384-tP0Wy54CKmng7i9EoTlPySD0hBx6Octj0VS6MfwlnUu111MPa+JLm0CCbep6XJ1W" crossorigin="anonymous"></script>
   <script src="/js/base64.js" integrity="sha384-dPTAiUm9yBw/r5Adl39R/YFMjDuMdHLZzDlXUciVyVhDdowN5rilt9FSG8+ca8Z5" crossorigin="anonymous"></script>
   <script src="/js/auth.js" integrity="sha384-nO5uz/Sdf8MxdDYah9a6DTEYrerBtkEwRzF8NZOj4z/3XCN+U1cGFKc07NanAY7Z" crossorigin="anonymous"></script>
-  <script src="/js/invite.js" integrity="sha384-7cS5jdLgwcaSMRrO8IzEiRXW1H6N7Ja2UC+1Ld/9gUxamt//Y2G5yetnJ59lnQt0" crossorigin="anonymous"></script>
+  <script src="/js/invite.js" integrity="sha384-vB2sNpoEhUhGjqIcgYE2GP2ZUJQ2lSWHgy+BebovZvOMENTXPSalLxzHy4II8+nh" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/static/js/invite.js
+++ b/static/js/invite.js
@@ -18,6 +18,11 @@
   const submitBtn = registerForm.querySelector('button[type="submit"]');
   const successPanel = document.getElementById('success-panel');
 
+  // Minimum secret length enforced at registration only.
+  // Login must NOT enforce this — existing users may have shorter secrets;
+  // a wrong secret simply derives a non-matching keypair rather than locking out.
+  const MIN_SECRET_LENGTH = 12;
+
   // State
   let inviteToken = null;
 
@@ -74,8 +79,8 @@
       return;
     }
 
-    if (secret.length < 8) {
-      showError('Secret must be at least 8 characters long.');
+    if (secret.length < MIN_SECRET_LENGTH) {
+      showError(`Secret must be at least ${MIN_SECRET_LENGTH} characters long. Your keypair is derived from this secret — a longer secret resists offline cracking.`);
       return;
     }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1317,6 +1317,14 @@ async fn test_admin_revoke_user() {
         .any(|u| u["alias"].as_str() == Some(&user_alias));
     assert!(has_user, "User should appear in list before revocation");
 
+    // Pubkey must NOT be exposed in the response (it is brute-force material)
+    for user in users.as_array().unwrap() {
+        assert!(
+            user.get("pubkey").is_none(),
+            "pubkey must not be present in /api/users response"
+        );
+    }
+
     // Find the user's ID from the list
     let user_id = users
         .as_array()


### PR DESCRIPTION
## Summary

User keypairs derive deterministically from `Argon2id(secret, salt=alias)`. That means anyone holding a public key can brute-force the corresponding secret entirely offline — no rate limits apply, and dictionaries per alias (e.g. `admin`) are precomputable. Public keys are therefore not safe to publish under this design, but `GET /api/users` returned all of them and the docs never warned about `ADMIN_PUBKEY`.

## Changes

- `GET /api/users` no longer returns the `pubkey` field (field removed from `UserInfo`); responses carry id, alias, role, created_at only. Admin revocation already keys on user id, so nothing functional changes.
- Admin UI: removed the public-key column from the users table (colspans updated everywhere, including empty/error states).
- README: `ADMIN_PUBKEY` is now documented as confidential (treat like a password hash), plus a new section explaining the alias-as-salt tradeoff and its consequences.
- Registration secret minimum raised from 8 to 12 characters (`MIN_SECRET_LENGTH` constant), with an explanatory message. Login intentionally does not enforce length — existing users with shorter secrets must not be locked out, and a wrong secret simply derives a non-matching keypair.
- Integration test asserts the user-list response contains no `pubkey` field.
- SRI hashes regenerated for changed JS.

Server-stored random per-user salt (removing the offline-cracking vector entirely at the cost of portability) is left as a follow-up.

## Tests

66 unit + 44 integration tests pass; fmt/clippy clean; vendor SRI verified; Docker build OK.
