### PR TITLE
fix: global per-paste PIN attempt limit (distributed brute-force)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,10 @@ CHALLENGE_TTL_SECS=30
 # Rate limiting
 RATE_LIMIT_PASTE_PER_MIN=10
 RATE_LIMIT_AUTH_PER_MIN=5
+# Per-IP PIN attempt limit (60s window)
+RATE_LIMIT_PIN_ATTEMPT=5
+# Global per-paste PIN attempt limit (1h window); bounds distributed brute-force
+RATE_LIMIT_PIN_ATTEMPT_GLOBAL=30
 
 # Proxy configuration
 # Number of trusted reverse proxies in front of the application.

--- a/src/config.rs
+++ b/src/config.rs
@@ -30,6 +30,7 @@ pub struct Config {
     pub rate_limit_paste_per_min: u32,
     pub rate_limit_auth_per_min: u32,
     pub rate_limit_pin_attempt: u32,
+    pub rate_limit_pin_attempt_global: u32,
 
     // Proxy
     pub trusted_proxy_count: usize,
@@ -62,6 +63,10 @@ impl std::fmt::Debug for Config {
             .field("rate_limit_paste_per_min", &self.rate_limit_paste_per_min)
             .field("rate_limit_auth_per_min", &self.rate_limit_auth_per_min)
             .field("rate_limit_pin_attempt", &self.rate_limit_pin_attempt)
+            .field(
+                "rate_limit_pin_attempt_global",
+                &self.rate_limit_pin_attempt_global,
+            )
             .field("trusted_proxy_count", &self.trusted_proxy_count)
             .field("max_sessions_per_user", &self.max_sessions_per_user)
             .field("max_pastes_per_user", &self.max_pastes_per_user)
@@ -164,6 +169,8 @@ impl Config {
         let rate_limit_paste_per_min = parse_env_or_default("RATE_LIMIT_PASTE_PER_MIN", 10)?;
         let rate_limit_auth_per_min = parse_env_or_default("RATE_LIMIT_AUTH_PER_MIN", 5)?;
         let rate_limit_pin_attempt = parse_env_or_default("RATE_LIMIT_PIN_ATTEMPT", 5)?;
+        let rate_limit_pin_attempt_global =
+            parse_env_or_default("RATE_LIMIT_PIN_ATTEMPT_GLOBAL", 30)?;
 
         // Proxy configuration
         let trusted_proxy_count = parse_env_or_default("TRUSTED_PROXY_COUNT", 0)?;
@@ -209,6 +216,7 @@ impl Config {
             rate_limit_paste_per_min,
             rate_limit_auth_per_min,
             rate_limit_pin_attempt,
+            rate_limit_pin_attempt_global,
             trusted_proxy_count,
             max_sessions_per_user,
             max_pastes_per_user,
@@ -260,6 +268,7 @@ mod tests {
         env::remove_var("RATE_LIMIT_PASTE_PER_MIN");
         env::remove_var("RATE_LIMIT_AUTH_PER_MIN");
         env::remove_var("RATE_LIMIT_PIN_ATTEMPT");
+        env::remove_var("RATE_LIMIT_PIN_ATTEMPT_GLOBAL");
         env::remove_var("TRUSTED_PROXY_COUNT");
         env::remove_var("MAX_SESSIONS_PER_USER");
         env::remove_var("MAX_PASTES_PER_USER");
@@ -497,6 +506,7 @@ mod tests {
         env::set_var("RATE_LIMIT_PASTE_PER_MIN", "10");
         env::set_var("RATE_LIMIT_AUTH_PER_MIN", "5");
         env::set_var("RATE_LIMIT_PIN_ATTEMPT", "5");
+        env::set_var("RATE_LIMIT_PIN_ATTEMPT_GLOBAL", "30");
         env::set_var("MAX_SESSIONS_PER_USER", "5");
         env::set_var("MAX_PASTES_PER_USER", "50");
 
@@ -517,6 +527,7 @@ mod tests {
         assert_eq!(config.rate_limit_paste_per_min, 10);
         assert_eq!(config.rate_limit_auth_per_min, 5);
         assert_eq!(config.rate_limit_pin_attempt, 5);
+        assert_eq!(config.rate_limit_pin_attempt_global, 30);
         assert_eq!(config.max_sessions_per_user, 5);
         assert_eq!(config.max_pastes_per_user, 50);
         assert_eq!(

--- a/src/routes/paste.rs
+++ b/src/routes/paste.rs
@@ -339,6 +339,18 @@ pub async fn attempt_paste(
 
     let mut con = state.redis.clone();
 
+    // Rate limit globally per paste (distributed brute-force protection).
+    // Check global first so an exhausted paste doesn't leak per-IP budget.
+    let global_key = format!("ratelimit:pin_attempt_global:{}", id);
+    super::enforce_rate_limit(
+        &mut con,
+        &global_key,
+        state.config.rate_limit_pin_attempt_global,
+        3600,
+        Some(("pin_attempt_global", &id)),
+    )
+    .await?;
+
     // Rate limit per IP per paste
     let ip = super::client_ip(&headers, &addr, state.config.trusted_proxy_count);
     let ip_hash = super::hash_ip(&*state.ip_hmac_salt, &ip);
@@ -348,7 +360,7 @@ pub async fn attempt_paste(
         &rate_limit_key,
         state.config.rate_limit_pin_attempt,
         60,
-        Some(("pin_attempt", &ip_hash)),
+        Some(("pin_attempt_per_ip", &ip_hash)),
     )
     .await?;
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -120,6 +120,7 @@ async fn main() {
         test_pin_gated_attempt_returns_content,
         test_pin_gated_attempt_wrong_verifier_returns_403,
         test_pin_gated_attempt_rate_limited,
+        test_pin_gated_global_attempt_rate_limited,
         test_pin_gated_burn_consumed_on_attempt,
         test_non_pin_attempt_returns_404,
         test_non_pin_get_unchanged,
@@ -162,9 +163,33 @@ async fn spawn_test_server() -> (String, redis::aio::ConnectionManager, SigningK
     spawn_test_server_with_auth_limit(10000).await
 }
 
-/// Spin up a test server with a custom auth rate limit.
-async fn spawn_test_server_with_auth_limit(
-    limit: u32,
+/// Overrides for [`spawn_test_server_configured`]. Only the fields that differ
+/// between test scenarios need to be set; everything else stays at safe defaults.
+struct TestServerOverrides {
+    rate_limit_auth_per_min: u32,
+    rate_limit_pin_attempt: u32,
+    rate_limit_pin_attempt_global: u32,
+    /// Number of trusted proxies (affects which XFF entry is used as client IP).
+    trusted_proxy_count: usize,
+}
+
+impl Default for TestServerOverrides {
+    fn default() -> Self {
+        Self {
+            rate_limit_auth_per_min: 10000,
+            rate_limit_pin_attempt: 10000,
+            rate_limit_pin_attempt_global: 10000,
+            trusted_proxy_count: 0,
+        }
+    }
+}
+
+/// Core helper: spin up a test server with configurable rate limits.
+///
+/// All callers go through this function. Varying fields are supplied via
+/// `TestServerOverrides`; everything else is fixed to safe test defaults.
+async fn spawn_test_server_configured(
+    overrides: TestServerOverrides,
 ) -> (String, redis::aio::ConnectionManager, SigningKey, String) {
     let (admin_key, admin_pubkey) = test_keypair();
     let admin_alias = format!("testadmin_{}", nanoid::nanoid!(6));
@@ -177,12 +202,10 @@ async fn spawn_test_server_with_auth_limit(
         .expect("Failed to get connection manager");
     let mut con = redis_manager.clone();
 
-    // Set up admin user
     nullpad::storage::user::upsert_admin(&mut con, &admin_pubkey, &admin_alias)
         .await
         .expect("Failed to upsert admin");
 
-    // Create temp directory for paste storage
     let paste_storage_path =
         std::env::temp_dir().join(format!("nullpad_test_{}", nanoid::nanoid!(8)));
     storage::blob::init_storage(&paste_storage_path)
@@ -203,9 +226,10 @@ async fn spawn_test_server_with_auth_limit(
         session_ttl_secs: 900,
         challenge_ttl_secs: 30,
         rate_limit_paste_per_min: 10000,
-        rate_limit_auth_per_min: limit,
-        rate_limit_pin_attempt: 10000,
-        trusted_proxy_count: 0,
+        rate_limit_auth_per_min: overrides.rate_limit_auth_per_min,
+        rate_limit_pin_attempt: overrides.rate_limit_pin_attempt,
+        rate_limit_pin_attempt_global: overrides.rate_limit_pin_attempt_global,
+        trusted_proxy_count: overrides.trusted_proxy_count,
         max_sessions_per_user: 5,
         max_pastes_per_user: 50,
         paste_storage_path,
@@ -240,80 +264,30 @@ async fn spawn_test_server_with_auth_limit(
     (base_url, con, admin_key, admin_alias)
 }
 
-/// Spin up a test server with a custom PIN attempt rate limit.
-async fn spawn_test_server_with_pin_limit(
+/// Spin up a test server with a custom auth rate limit.
+async fn spawn_test_server_with_auth_limit(
     limit: u32,
 ) -> (String, redis::aio::ConnectionManager, SigningKey, String) {
-    let (admin_key, admin_pubkey) = test_keypair();
-    let admin_alias = format!("testadmin_{}", nanoid::nanoid!(6));
+    spawn_test_server_configured(TestServerOverrides {
+        rate_limit_auth_per_min: limit,
+        ..Default::default()
+    })
+    .await
+}
 
-    let test_redis_url = get_redis_url().to_string();
-    let redis_client = redis::Client::open(test_redis_url.as_str()).expect("Failed to open Redis");
-    let redis_manager = redis_client
-        .get_connection_manager()
-        .await
-        .expect("Failed to get connection manager");
-    let mut con = redis_manager.clone();
-
-    nullpad::storage::user::upsert_admin(&mut con, &admin_pubkey, &admin_alias)
-        .await
-        .expect("Failed to upsert admin");
-
-    let paste_storage_path =
-        std::env::temp_dir().join(format!("nullpad_test_{}", nanoid::nanoid!(8)));
-    nullpad::storage::blob::init_storage(&paste_storage_path)
-        .await
-        .expect("Failed to init paste storage");
-
-    let config = Config {
-        admin_pubkey,
-        admin_alias: admin_alias.clone(),
-        redis_url: test_redis_url.clone(),
-        bind_addr: "127.0.0.1:0".parse().unwrap(),
-        max_upload_bytes: 52_428_800,
-        default_ttl_secs: 86400,
-        max_ttl_secs: 604800,
-        invite_ttl_secs: 43200,
-        user_idle_ttl_secs: 172800,
-        user_active_ttl_secs: 86400,
-        session_ttl_secs: 900,
-        challenge_ttl_secs: 30,
-        rate_limit_paste_per_min: 10000,
-        rate_limit_auth_per_min: 10000,
-        rate_limit_pin_attempt: limit,
-        trusted_proxy_count: 0,
-        max_sessions_per_user: 5,
-        max_pastes_per_user: 50,
-        paste_storage_path,
-    };
-
-    let state = AppState {
-        redis: redis_manager,
-        config: Arc::new(config),
-        ip_hmac_salt: Arc::new(rand::random()),
-    };
-
-    let app = routes::api_router()
-        .fallback_service(ServeDir::new("static"))
-        .layer(axum::middleware::from_fn(security_headers))
-        .with_state(state);
-
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-        .await
-        .expect("Failed to bind");
-    let addr = listener.local_addr().unwrap();
-
-    tokio::spawn(async move {
-        axum::serve(
-            listener,
-            app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
-        )
-        .await
-        .unwrap();
-    });
-
-    let base_url = format!("http://{}", addr);
-    (base_url, con, admin_key, admin_alias)
+/// Spin up a test server with custom per-IP and global PIN attempt rate limits.
+/// Uses `trusted_proxy_count=1` so XFF headers control client IP selection.
+async fn spawn_test_server_with_pin_limits(
+    per_ip_limit: u32,
+    global_limit: u32,
+) -> (String, redis::aio::ConnectionManager, SigningKey, String) {
+    spawn_test_server_configured(TestServerOverrides {
+        rate_limit_pin_attempt: per_ip_limit,
+        rate_limit_pin_attempt_global: global_limit,
+        trusted_proxy_count: 1,
+        ..Default::default()
+    })
+    .await
 }
 
 /// Helper: perform full challenge -> sign -> verify login flow, return session token.
@@ -2045,6 +2019,28 @@ async fn test_trusted_user_can_upload_files() {
 // PIN Gating Tests
 // ============================================================================
 
+/// POST a PIN attempt with a spoofed client IP via X-Forwarded-For.
+///
+/// `client_ip_suffix` sets the last octet of a 10.0.0.N address in the XFF
+/// header alongside a fixed trusted proxy IP, giving each distinct suffix its
+/// own per-IP rate-limit bucket.
+async fn pin_attempt_with_xff(
+    client: &reqwest::Client,
+    base_url: &str,
+    id: &str,
+    verifier: &str,
+    client_ip_suffix: u8,
+) -> Result<reqwest::Response, reqwest::Error> {
+    let xff = format!("10.0.0.{}, 192.168.1.1", client_ip_suffix);
+    client
+        .post(format!("{}/api/paste/{}", base_url, id))
+        .header("Content-Type", "application/json")
+        .header("X-Forwarded-For", xff)
+        .body(serde_json::json!({ "pin_verifier": verifier }).to_string())
+        .send()
+        .await
+}
+
 async fn test_pin_gated_get_returns_needs_pin() {
     let (base_url, _con, _admin_key, _admin_alias) = spawn_test_server().await;
     let client = reqwest::Client::new();
@@ -2171,8 +2167,9 @@ async fn test_pin_gated_attempt_wrong_verifier_returns_403() {
 }
 
 async fn test_pin_gated_attempt_rate_limited() {
-    // Use a server with very low PIN attempt limit
-    let (base_url, _con, _admin_key, _admin_alias) = spawn_test_server_with_pin_limit(2).await;
+    // per-IP limit = 2, global limit = 10000 (well above attempt count, won't fire)
+    let (base_url, _con, _admin_key, _admin_alias) =
+        spawn_test_server_with_pin_limits(2, 10000).await;
     let client = reqwest::Client::new();
 
     // Create a PIN-gated paste
@@ -2214,6 +2211,81 @@ async fn test_pin_gated_attempt_rate_limited() {
         .await
         .unwrap();
     assert_eq!(resp.status(), 429);
+    let retry_after: u64 = resp
+        .headers()
+        .get("retry-after")
+        .expect("429 must include Retry-After header")
+        .to_str()
+        .unwrap()
+        .parse()
+        .expect("Retry-After must be a positive integer");
+    assert!(retry_after > 0, "Retry-After must be positive");
+}
+
+async fn test_pin_gated_global_attempt_rate_limited() {
+    // Global cap = 3. Per-IP cap = 100: set well above the 3 attempts made here
+    // so only the global cap can fire, not any per-IP bucket.
+    // Three distinct client IPs each make 1 attempt (each under per-IP limit).
+    // The 4th attempt from yet another IP must be 429 due to global cap.
+    let (base_url, _con, _admin_key, _admin_alias) =
+        spawn_test_server_with_pin_limits(100, 3).await;
+    let client = reqwest::Client::new();
+
+    // Create a PIN-gated paste
+    let resp = create_paste(
+        &client,
+        &base_url,
+        "text",
+        b"global secret",
+        false,
+        3600,
+        None,
+        true,
+    )
+    .await;
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    let id = body["id"].as_str().unwrap().to_string();
+
+    let dummy_key = test_dummy_key();
+    let verifier = test_pin_verifier(&dummy_key, &id);
+
+    // Three distinct client IPs, each within per-IP limit → correct PIN → 200.
+    //
+    // With trusted_proxy_count=1, client_ip() reads XFF[len - 1 - 1] = XFF[0]
+    // from a two-entry header "10.0.0.N, 192.168.1.1", so 10.0.0.N is the client
+    // IP. Each distinct N lands in its own per-IP rate-limit bucket.
+    for ip_suffix in 1u8..=3 {
+        let resp = pin_attempt_with_xff(&client, &base_url, &id, &verifier, ip_suffix)
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            200,
+            "Expected 200 for client IP 10.0.0.{}, got {}",
+            ip_suffix,
+            resp.status()
+        );
+    }
+
+    // 4th attempt from a fresh IP — global cap exhausted → 429
+    let resp = pin_attempt_with_xff(&client, &base_url, &id, &verifier, 4)
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        429,
+        "Expected 429 after global cap exhausted"
+    );
+    let retry_after: u64 = resp
+        .headers()
+        .get("retry-after")
+        .expect("429 must include Retry-After header")
+        .to_str()
+        .unwrap()
+        .parse()
+        .expect("Retry-After must be a positive integer");
+    assert!(retry_after > 0, "Retry-After must be positive");
 }
 
 async fn test_pin_gated_burn_consumed_on_attempt() {


### PR DESCRIPTION
## Summary

PIN attempts were rate-limited only per `{ip_hash}:{paste_id}`, so an attacker with a proxy pool (or any IP-spoofing vector) gets the full per-IP budget for every source address — the total guess budget against a single paste was unbounded. The PIN exists specifically to protect intercepted URLs, so total per-paste guesses must be bounded.

## Changes

- New Redis counter `ratelimit:pin_attempt_global:{paste_id}` checked in `attempt_paste()` before the per-IP limit, so a locked-out paste doesn't leak per-IP budget state. Window is 1 hour (vs 60s per-IP) so a pool can't simply wait out the minute.
- New config: `RATE_LIMIT_PIN_ATTEMPT_GLOBAL` (default 30/hour) — enough headroom for several legitimate users mistyping, while bounding distributed guessing. Documented in `.env.example` along with the previously undocumented `RATE_LIMIT_PIN_ATTEMPT`.
- Rate-limit log labels made parallel: `pin_attempt_global` / `pin_attempt_per_ip` (hashed identities only, as before).
- Integration test: three distinct client IPs (via X-Forwarded-For with `trusted_proxy_count=1`) each make one attempt against a paste with global cap 3 and per-IP cap 100; a fourth IP gets 429 with a valid `Retry-After`. Test helpers refactored into a shared config builder, removing ~100 lines of duplicated setup.
- Both PIN rate-limit tests now assert the `Retry-After` header parses as a positive integer.

## Tests

66 unit + 45 integration tests pass; fmt/clippy clean; Docker build OK.
