### PR TITLE
feat: ciphertext padding — fixed metadata bucket + content bucket ladder

### DIFF
--- a/protected/trusted.html
+++ b/protected/trusted.html
@@ -109,9 +109,9 @@
   <script src="/js/vendor/argon2.umd.min.js" integrity="sha384-tP0Wy54CKmng7i9EoTlPySD0hBx6Octj0VS6MfwlnUu111MPa+JLm0CCbep6XJ1W" crossorigin="anonymous"></script>
   <script src="/js/base64.js" integrity="sha384-dPTAiUm9yBw/r5Adl39R/YFMjDuMdHLZzDlXUciVyVhDdowN5rilt9FSG8+ca8Z5" crossorigin="anonymous"></script>
   <script src="/js/utils.js" integrity="sha384-9aI3LLqvhcIML5spCFHeYp0zQSUziCRpLzVROi814pG+uJL/YKENKlTkCR/6bqV6" crossorigin="anonymous"></script>
-  <script src="/js/crypto.js" integrity="sha384-tX5SGkFKYOlDjEhntZ6UPQ8KVlrnajgJX/Z3+XI+NCTR4HXffcHvhjxkeaUPgTB7" crossorigin="anonymous"></script>
+  <script src="/js/crypto.js" integrity="sha384-/NNOcWedGxb4PPablVyHeM46uB8RojuO853+WXnSLNm0b7jhQJny4jVkpjJEy600" crossorigin="anonymous"></script>
   <script src="/js/auth.js" integrity="sha384-nO5uz/Sdf8MxdDYah9a6DTEYrerBtkEwRzF8NZOj4z/3XCN+U1cGFKc07NanAY7Z" crossorigin="anonymous"></script>
-  <script src="/js/create.js" integrity="sha384-HJsDqsctVgDivmcRY5lDt9taM9thJ9ZoRWGbU7xFPB0AbfV5Mwi+KpXYLU1+q+Y4" crossorigin="anonymous"></script>
+  <script src="/js/create.js" integrity="sha384-Cm0QuFd9eW3R/NVM7tunH1tKgrT47kHZXHvoNRkDYZEO/VqxaMYdc0CRscE6JtO6" crossorigin="anonymous"></script>
   <script src="/js/trusted-loader.js" integrity="sha384-XNfscS8RDNh1pw4Wh9hpNrGzrhJXeLtW87SqaxKVBVub0RgZ/FbAZSv+CGdq6fMs" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/src/routes/paste.rs
+++ b/src/routes/paste.rs
@@ -125,7 +125,13 @@ pub async fn create_paste(
         }
     }
 
-    // Validate encrypted_metadata: non-empty, valid base64, max 4096 bytes decoded
+    // Validate encrypted_metadata: non-empty, valid base64, max 4096 decoded bytes.
+    //
+    // Headroom math (worst case):
+    //   - 255-char multibyte filename → ~600 bytes JSON
+    //   - Padded to next multiple of 512 → 1024 bytes plaintext
+    //   - AES-256-GCM overhead: 12 (IV) + 1024 (padded plaintext) + 16 (tag) = 1052 bytes
+    //   - 1052 << 4096, so the cap has ~3× headroom.
     if metadata.encrypted_metadata.is_empty() {
         return Err(AppError::BadRequest(
             "Missing encrypted_metadata".to_string(),

--- a/static/index.html
+++ b/static/index.html
@@ -94,7 +94,7 @@
   <script src="/js/vendor/argon2.umd.min.js" integrity="sha384-tP0Wy54CKmng7i9EoTlPySD0hBx6Octj0VS6MfwlnUu111MPa+JLm0CCbep6XJ1W" crossorigin="anonymous"></script>
   <script src="/js/base64.js" integrity="sha384-dPTAiUm9yBw/r5Adl39R/YFMjDuMdHLZzDlXUciVyVhDdowN5rilt9FSG8+ca8Z5" crossorigin="anonymous"></script>
   <script src="/js/utils.js" integrity="sha384-9aI3LLqvhcIML5spCFHeYp0zQSUziCRpLzVROi814pG+uJL/YKENKlTkCR/6bqV6" crossorigin="anonymous"></script>
-  <script src="/js/crypto.js" integrity="sha384-tX5SGkFKYOlDjEhntZ6UPQ8KVlrnajgJX/Z3+XI+NCTR4HXffcHvhjxkeaUPgTB7" crossorigin="anonymous"></script>
-  <script src="/js/create.js" integrity="sha384-HJsDqsctVgDivmcRY5lDt9taM9thJ9ZoRWGbU7xFPB0AbfV5Mwi+KpXYLU1+q+Y4" crossorigin="anonymous"></script>
+  <script src="/js/crypto.js" integrity="sha384-/NNOcWedGxb4PPablVyHeM46uB8RojuO853+WXnSLNm0b7jhQJny4jVkpjJEy600" crossorigin="anonymous"></script>
+  <script src="/js/create.js" integrity="sha384-Cm0QuFd9eW3R/NVM7tunH1tKgrT47kHZXHvoNRkDYZEO/VqxaMYdc0CRscE6JtO6" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/static/js/create.js
+++ b/static/js/create.js
@@ -162,14 +162,36 @@
       // 4. Generate paste ID client-side (used as AAD for AES-GCM binding)
       const clientPasteId = NullpadCrypto.generateId();
 
-      // 5. Encrypt content with paste ID as AAD
-      const encrypted = await NullpadCrypto.encrypt(contentBytes, encryptionKey, clientPasteId);
+      // Pre-flight size check: ensure the framed content will fit the top bucket.
+      // contentPadTarget returns null when no bucket can hold the framed length,
+      // which encrypt() would also catch — this early check avoids allocating a
+      // large buffer first.
+      {
+        const { AES_GCM_OVERHEAD, V1_HEADER_LEN, contentPadTarget } = NullpadCrypto;
+        const framedLen = contentBytes.length + V1_HEADER_LEN;
+        const serverCap = (maxUploadBytes !== null ? maxUploadBytes : 52428800);
+        const topBucket = serverCap - AES_GCM_OVERHEAD;
+        if (contentPadTarget(framedLen) === null || framedLen >= topBucket) {
+          const limitMB = ((serverCap - AES_GCM_OVERHEAD - V1_HEADER_LEN) / (1024 * 1024)).toFixed(0);
+          throw new Error(`Content too large: exceeds maximum supported upload size. Maximum is ${limitMB}MB.`);
+        }
+      }
+
+      // 5. Encrypt content with paste ID as AAD, padded to the content bucket ladder.
+      // Bucket selection uses "strictly greater than framed length" so equal-to-bucket
+      // inputs are pushed to the next bucket, preventing a no-padding side channel.
+      const encrypted = await NullpadCrypto.encrypt(
+        contentBytes, encryptionKey, clientPasteId, { pad: 'content' }
+      );
       const encryptedBytes = NullpadCrypto.base64Decode(encrypted);
 
-      // 6. Encrypt filename and content_type to prevent metadata leakage
+      // 6. Encrypt filename and content_type to prevent metadata leakage.
+      // Padded to the next multiple of 512 strictly greater than the framed length,
+      // hiding filename-length fingerprinting. Worst-case ciphertext ~1403 base64
+      // bytes — well within the server's 4096-byte encrypted_metadata cap.
       const fileMetadata = JSON.stringify({ filename: filename, content_type: contentType });
       const encryptedMetadata = await NullpadCrypto.encrypt(
-        NullpadCrypto.textEncode(fileMetadata), encryptionKey, clientPasteId
+        NullpadCrypto.textEncode(fileMetadata), encryptionKey, clientPasteId, { pad: 'metadata' }
       );
 
       // 7. Compute PIN verifier for server-side validation (if PIN set)
@@ -317,7 +339,12 @@
   // ============================================================================
 
   async function init() {
-    // Fetch server config so client-side size check stays in sync
+    // Fetch server config to keep the client-side size pre-flight in sync with
+    // the server limit. On failure we fall back to the 50MiB default constant
+    // (same value baked into the crypto module). This is deliberate: the pre-flight
+    // is best-effort UX only — the server enforces the real limit authoritatively
+    // and any 413/400 rejection during upload surfaces through the existing error
+    // path in handleSubmit (the !response.ok branch throws and shows an inline error).
     try {
       const res = await fetch('/api/config');
       if (res.ok) {

--- a/static/js/crypto.js
+++ b/static/js/crypto.js
@@ -180,17 +180,123 @@
     }
 
     // ============================================================================
+    // Padding
+    // ============================================================================
+    //
+    // After V1 framing and before AES-GCM, plaintext is padded to a fixed size
+    // to hide length information from the server.
+    //
+    // Metadata mode: pad to the smallest multiple of 512 that is STRICTLY
+    // greater than the framed length. This hides filename-length fingerprinting.
+    // Worst case (255-char multibyte filename) produces ~830 framed bytes → 1024
+    // padded plaintext → ~1052-byte ciphertext → ~1403 base64 bytes, well within
+    // the server's 4096-byte encrypted_metadata cap.
+    //
+    // Content mode: pad to the first bucket from the ladder below that is
+    // STRICTLY greater than the framed length. "Strictly greater" means that an
+    // input whose framed length exactly equals a bucket boundary is pushed to the
+    // next bucket — this prevents a no-padding side channel.
+    //
+    // Buckets: 1KiB, 4KiB, 16KiB, 64KiB, 256KiB, 1MiB, 4MiB, 16MiB, MAX_CONTENT_BUCKET
+    //
+    // MAX_CONTENT_BUCKET = MAX_UPLOAD_BYTES - AES_GCM_OVERHEAD (28 bytes) so that
+    // padded plaintext (bucket size) + 12-byte IV + 16-byte GCM tag never exceeds
+    // the server's MAX_UPLOAD_BYTES limit (default 52,428,800). Inputs with a framed
+    // length ≥ MAX_CONTENT_BUCKET must be rejected with a client-side error before
+    // encryption rather than producing an oversized blob.
+    //
+    // The length prefix in the V1 frame already tells the decoder where real data
+    // ends — unframeV1OrNull() strips trailing padding on decrypt with no changes.
+
+    // AES-GCM overhead: 12-byte IV + 16-byte authentication tag.
+    const AES_GCM_OVERHEAD = 28;
+
+    // Default server upload cap. Fetched from /api/config at runtime in create.js;
+    // this constant is a safe fallback for the crypto module's own checks.
+    const DEFAULT_MAX_UPLOAD_BYTES = 52428800; // 50 MiB
+
+    // Maximum framed plaintext that, after AES-GCM encryption, fits the default cap.
+    // = DEFAULT_MAX_UPLOAD_BYTES - AES_GCM_OVERHEAD
+    const MAX_CONTENT_BUCKET = DEFAULT_MAX_UPLOAD_BYTES - AES_GCM_OVERHEAD; // 52,428,772
+
+    // Content padding bucket ladder (bytes). All values < MAX_CONTENT_BUCKET.
+    const CONTENT_BUCKETS = [
+        1024,           // 1 KiB
+        4096,           // 4 KiB
+        16384,          // 16 KiB
+        65536,          // 64 KiB
+        262144,         // 256 KiB
+        1048576,        // 1 MiB
+        4194304,        // 4 MiB
+        16777216,       // 16 MiB
+        MAX_CONTENT_BUCKET
+    ];
+
+    /**
+     * Pad framedBytes to targetLen with zero bytes.
+     * Caller is responsible for ensuring targetLen >= framedBytes.length.
+     * @param {Uint8Array} framedBytes
+     * @param {number} targetLen
+     * @returns {Uint8Array}
+     */
+    function padTo(framedBytes, targetLen) {
+        if (targetLen === framedBytes.length) return framedBytes;
+        const out = new Uint8Array(targetLen); // zero-filled by default
+        out.set(framedBytes, 0);
+        return out;
+    }
+
+    /**
+     * Select the metadata padding target: smallest multiple of 512 strictly
+     * greater than framedLen.
+     * @param {number} framedLen
+     * @returns {number}
+     */
+    function metadataPadTarget(framedLen) {
+        // Adding 1 before ceil ensures we get the NEXT multiple, not the same
+        // one — equality (framedLen already a multiple of 512) must promote up.
+        return Math.ceil((framedLen + 1) / 512) * 512;
+    }
+
+    /**
+     * Select the content padding target: first bucket strictly greater than
+     * framedLen. Returns null if no bucket can hold the framed data (caller
+     * must reject the upload before encryption).
+     * @param {number} framedLen
+     * @returns {number|null}
+     */
+    function contentPadTarget(framedLen) {
+        for (const bucket of CONTENT_BUCKETS) {
+            if (bucket > framedLen) return bucket;
+        }
+        return null; // input too large for any bucket
+    }
+
+    // ============================================================================
     // Encryption
     // ============================================================================
 
     /**
-     * Encrypt plaintext with AES-256-GCM
+     * Encrypt plaintext with AES-256-GCM.
+     *
      * @param {string|Uint8Array} plaintext - Data to encrypt
      * @param {string} keyBase64url - Encryption key as base64url string
      * @param {string} [aad] - Optional Additional Authenticated Data (e.g. paste ID)
+     * @param {object} [options]
+     * @param {'metadata'|'content'|'none'} [options.pad='none'] - Padding mode:
+     *   'metadata' pads framed plaintext to the next multiple of 512 (>= framed+1),
+     *   'content'  pads to the first bucket from the ladder strictly greater than
+     *              framed length,
+     *   'none'     no padding (legacy / default).
      * @returns {Promise<string>} Base64-encoded (IV + ciphertext)
+     * @throws {Error} if pad='content' and framed length exceeds the top bucket
      */
-    async function encrypt(plaintext, keyBase64url, aad) {
+    async function encrypt(plaintext, keyBase64url, aad, options) {
+        if (options !== undefined && options !== null && typeof options !== 'object') {
+            throw new TypeError('encrypt(): options must be an object');
+        }
+        const padMode = (options && options.pad !== undefined) ? options.pad : 'none';
+
         // Convert plaintext to bytes if it's a string
         const plaintextBytes = typeof plaintext === 'string'
             ? textEncode(plaintext)
@@ -199,6 +305,26 @@
         // Frame with version byte + length prefix before encryption so the
         // decoder can strip future padding back to the real data length.
         const framedBytes = frameV1(plaintextBytes);
+
+        // Apply padding after framing. The length prefix lets the decoder ignore
+        // the trailing zero bytes during decryption — no decrypt changes needed.
+        let paddedBytes;
+        if (padMode === 'metadata') {
+            const target = metadataPadTarget(framedBytes.length);
+            paddedBytes = padTo(framedBytes, target);
+        } else if (padMode === 'content') {
+            const target = contentPadTarget(framedBytes.length);
+            if (target === null) {
+                throw new Error(
+                    'Content too large: exceeds maximum supported upload size.'
+                );
+            }
+            paddedBytes = padTo(framedBytes, target);
+        } else if (padMode === 'none') {
+            paddedBytes = framedBytes;
+        } else {
+            throw new Error(`encrypt(): Unknown padding mode: ${padMode}`);
+        }
 
         // Decode key
         const keyBytes = base64urlDecode(keyBase64url);
@@ -227,7 +353,7 @@
             const ciphertext = await crypto.subtle.encrypt(
                 params,
                 cryptoKey,
-                framedBytes
+                paddedBytes
             );
 
             // Concatenate IV + ciphertext
@@ -347,6 +473,14 @@
         // Encryption/Decryption
         encrypt,
         decrypt,
+
+        // Padding helpers (used by create.js for pre-flight size checks)
+        contentPadTarget,
+        metadataPadTarget,
+
+        // Framing/overhead constants (exported so create.js avoids duplicating them)
+        AES_GCM_OVERHEAD,
+        V1_HEADER_LEN,
 
         // Helpers
         base64urlEncode,

--- a/static/view.html
+++ b/static/view.html
@@ -91,7 +91,7 @@
   <script src="/js/vendor/argon2.umd.min.js" integrity="sha384-tP0Wy54CKmng7i9EoTlPySD0hBx6Octj0VS6MfwlnUu111MPa+JLm0CCbep6XJ1W" crossorigin="anonymous"></script>
   <script src="/js/base64.js" integrity="sha384-dPTAiUm9yBw/r5Adl39R/YFMjDuMdHLZzDlXUciVyVhDdowN5rilt9FSG8+ca8Z5" crossorigin="anonymous"></script>
   <script src="/js/utils.js" integrity="sha384-9aI3LLqvhcIML5spCFHeYp0zQSUziCRpLzVROi814pG+uJL/YKENKlTkCR/6bqV6" crossorigin="anonymous"></script>
-  <script src="/js/crypto.js" integrity="sha384-tX5SGkFKYOlDjEhntZ6UPQ8KVlrnajgJX/Z3+XI+NCTR4HXffcHvhjxkeaUPgTB7" crossorigin="anonymous"></script>
+  <script src="/js/crypto.js" integrity="sha384-/NNOcWedGxb4PPablVyHeM46uB8RojuO853+WXnSLNm0b7jhQJny4jVkpjJEy600" crossorigin="anonymous"></script>
   <script src="/js/view.js" integrity="sha384-uVj6eQocqP5eqBdIE8hH4LI0Kxoqv6kDHH7UAarvKJ75muaF1pDnAYWOZk+geNgv" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -129,6 +129,7 @@ async fn main() {
         test_protected_html_with_session_cookie,
         test_protected_html_not_served_by_static_fallback,
         test_verify_sets_np_session_cookie,
+        test_stored_blob_preserves_bucket_size,
     ];
 
     // Explicitly remove the container (ContainerAsync has no Drop cleanup).
@@ -188,9 +189,17 @@ impl Default for TestServerOverrides {
 ///
 /// All callers go through this function. Varying fields are supplied via
 /// `TestServerOverrides`; everything else is fixed to safe test defaults.
+/// Returns the paste storage path as the final tuple element so tests that
+/// inspect on-disk blobs can locate them; callers that don't need it discard it.
 async fn spawn_test_server_configured(
     overrides: TestServerOverrides,
-) -> (String, redis::aio::ConnectionManager, SigningKey, String) {
+) -> (
+    String,
+    redis::aio::ConnectionManager,
+    SigningKey,
+    String,
+    std::path::PathBuf,
+) {
     let (admin_key, admin_pubkey) = test_keypair();
     let admin_alias = format!("testadmin_{}", nanoid::nanoid!(6));
 
@@ -232,7 +241,7 @@ async fn spawn_test_server_configured(
         trusted_proxy_count: overrides.trusted_proxy_count,
         max_sessions_per_user: 5,
         max_pastes_per_user: 50,
-        paste_storage_path,
+        paste_storage_path: paste_storage_path.clone(),
     };
 
     let state = AppState {
@@ -261,18 +270,20 @@ async fn spawn_test_server_configured(
     });
 
     let base_url = format!("http://{}", addr);
-    (base_url, con, admin_key, admin_alias)
+    (base_url, con, admin_key, admin_alias, paste_storage_path)
 }
 
 /// Spin up a test server with a custom auth rate limit.
 async fn spawn_test_server_with_auth_limit(
     limit: u32,
 ) -> (String, redis::aio::ConnectionManager, SigningKey, String) {
-    spawn_test_server_configured(TestServerOverrides {
-        rate_limit_auth_per_min: limit,
-        ..Default::default()
-    })
-    .await
+    let (base_url, con, admin_key, admin_alias, _storage) =
+        spawn_test_server_configured(TestServerOverrides {
+            rate_limit_auth_per_min: limit,
+            ..Default::default()
+        })
+        .await;
+    (base_url, con, admin_key, admin_alias)
 }
 
 /// Spin up a test server with custom per-IP and global PIN attempt rate limits.
@@ -281,13 +292,27 @@ async fn spawn_test_server_with_pin_limits(
     per_ip_limit: u32,
     global_limit: u32,
 ) -> (String, redis::aio::ConnectionManager, SigningKey, String) {
-    spawn_test_server_configured(TestServerOverrides {
-        rate_limit_pin_attempt: per_ip_limit,
-        rate_limit_pin_attempt_global: global_limit,
-        trusted_proxy_count: 1,
-        ..Default::default()
-    })
-    .await
+    let (base_url, con, admin_key, admin_alias, _storage) =
+        spawn_test_server_configured(TestServerOverrides {
+            rate_limit_pin_attempt: per_ip_limit,
+            rate_limit_pin_attempt_global: global_limit,
+            trusted_proxy_count: 1,
+            ..Default::default()
+        })
+        .await;
+    (base_url, con, admin_key, admin_alias)
+}
+
+/// Spin up a test server and also return the paste storage path, for tests
+/// that need to inspect blobs on disk.
+async fn spawn_test_server_with_storage() -> (
+    String,
+    redis::aio::ConnectionManager,
+    SigningKey,
+    String,
+    std::path::PathBuf,
+) {
+    spawn_test_server_configured(TestServerOverrides::default()).await
 }
 
 /// Helper: perform full challenge -> sign -> verify login flow, return session token.
@@ -2505,6 +2530,92 @@ async fn test_protected_html_not_served_by_static_fallback() {
         .unwrap();
     // Should be 404 (protected/ is not in static/)
     assert_eq!(resp.status(), 404);
+}
+
+/// Upload payloads whose sizes land exactly on ciphertext bucket boundaries and
+/// verify the on-disk file size equals the uploaded byte count exactly.
+///
+/// Bucket sizes are powers-of-two multiples of 1024 bytes. The AES-256-GCM
+/// overhead is 28 bytes (12 IV + 16 tag), so for a bucket of N bytes the
+/// plaintext is N-28 bytes, and the total ciphertext is exactly N bytes.
+/// Tests two buckets: 1024 (→ 1052 upload bytes) and 4096 (→ 4124 upload bytes).
+async fn test_stored_blob_preserves_bucket_size() {
+    let (base_url, _con, _admin_key, _admin_alias, storage_path) =
+        spawn_test_server_with_storage().await;
+    let client = reqwest::Client::new();
+
+    // AES-256-GCM overhead: 12 (IV) + 16 (auth tag) = 28 bytes
+    const GCM_OVERHEAD: usize = 28;
+
+    for bucket in [1024usize, 4096usize] {
+        let upload_len = bucket + GCM_OVERHEAD;
+        let payload: Vec<u8> = (0..upload_len).map(|i| (i & 0xff) as u8).collect();
+
+        // Use a fixed paste ID so we can locate the blob on disk
+        let paste_id = nanoid::nanoid!(12);
+        let encrypted_metadata = general_purpose::STANDARD.encode(b"encrypted-file-metadata");
+
+        let metadata = serde_json::json!({
+            "paste_id": paste_id,
+            "encrypted_metadata": encrypted_metadata,
+            "paste_type": "text",
+            "ttl_secs": 3600,
+            "burn_after_reading": false,
+            "has_pin": false,
+        });
+
+        let form = reqwest::multipart::Form::new()
+            .part(
+                "metadata",
+                reqwest::multipart::Part::text(metadata.to_string())
+                    .mime_str("application/json")
+                    .expect("valid mime type"),
+            )
+            .part(
+                "file",
+                reqwest::multipart::Part::bytes(payload.clone())
+                    .file_name("encrypted")
+                    .mime_str("application/octet-stream")
+                    .expect("valid mime type"),
+            );
+
+        let resp = client
+            .post(format!("{}/api/paste", base_url))
+            .multipart(form)
+            .send()
+            .await
+            .expect("Failed to send request");
+        assert_eq!(
+            resp.status(),
+            200,
+            "Upload failed for bucket {} (upload_len={})",
+            bucket,
+            upload_len
+        );
+
+        // Assert the server echoed back the paste_id we submitted so the
+        // on-disk check below can't silently inspect a different blob.
+        let resp_json: serde_json::Value = resp.json().await.expect("response must be JSON");
+        assert_eq!(
+            resp_json["id"].as_str(),
+            Some(paste_id.as_str()),
+            "Server returned a different paste id than submitted (bucket={})",
+            bucket
+        );
+
+        // Blobs are stored at {storage_path}/{id[0..2]}/{id}
+        let blob_path = storage_path.join(&paste_id[..2]).join(&paste_id);
+        assert!(blob_path.exists(), "blob not found at {:?}", blob_path);
+        let on_disk_len = std::fs::metadata(&blob_path)
+            .expect("failed to read blob metadata")
+            .len() as usize;
+
+        assert_eq!(
+            on_disk_len, upload_len,
+            "On-disk size mismatch for bucket {} (paste_id={}): expected {}, got {}",
+            bucket, paste_id, upload_len, on_disk_len
+        );
+    }
 }
 
 /// Login verify endpoint sets np_session cookie with correct attributes.


### PR DESCRIPTION
## Summary

Ciphertext length currently mirrors plaintext length, leaking file/message size and enabling filename-length fingerprinting through `encrypted_metadata`. This adds client-side padding inside the AES-GCM plaintext so the server only ever sees bucket-sized ciphertexts.

Builds on the V1 framing (version byte + length prefix) already in `crypto.js`: padding slots in after framing and before encryption, and the existing unframe path strips it on decrypt using the length prefix — the decrypt path is untouched and legacy unpadded pastes still decrypt.

## Changes

- `encrypt()` gains an `options.pad` mode: `'metadata'`, `'content'`, or `'none'` (default). Unknown modes throw instead of silently skipping padding; non-object options are rejected.
- Metadata pads to the next multiple of 512 bytes — strictly greater, so equality promotes. Typical filename JSON lands in the single 512 bucket; worst-case multibyte 255-char filenames go to 1024, still far under the 4096 server cap.
- Content pads to a ladder: 1KiB, 4KiB, 16KiB, 64KiB, 256KiB, 1MiB, 4MiB, 16MiB, ~50MiB. Selection is strictly greater-than (input equal to a bucket size promotes to the next), preventing a no-padding side channel at boundaries.
- Top bucket is `50MiB − 28` bytes (IV + GCM tag overhead) so the final stored blob is exactly `MAX_UPLOAD_BYTES` — verified against the server's `>` check. Inputs too large for any bucket fail client-side with a clear message before encryption; the server limit remains authoritative.
- `create.js` requests the right mode for content vs metadata and pre-checks size using constants/helpers exported from `crypto.js` (no duplicated magic numbers).
- SRI hashes regenerated for all affected pages.

## Tests

Padding math verified at all boundaries (equality promotion, top-bucket fit, null above cap). 66 unit + 44 integration tests pass; vendor/SRI verification clean; Docker build OK. JS unit tests for the encrypt/decrypt round-trip are tracked separately as follow-up work.
