### PR TITLE
chore: supply-chain hygiene — pin toolchain action, prune stale audit ignore, widen dockerignore

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -2,8 +2,6 @@
 # See: https://rustsec.org/
 
 [advisories]
-# Ignore RUSTSEC-2025-0134: rustls-pemfile unmaintained
-# - This is informational only (not a vulnerability)
-# - Dependency comes from testcontainers (dev-only)
-# - Will be resolved when bollard updates
-ignore = ["RUSTSEC-2025-0134"]
+# No ignores. RUSTSEC-2025-0134 (rustls-pemfile, dev-only via testcontainers)
+# was ignored here until the crate left the dependency tree; re-justify from
+# scratch if an ignore is ever needed again.

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 target/
 .git/
-.env
+.env*
+!.env.example
 .beads/
 .build/
 *.md

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,9 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: dtolnay/rust-toolchain@stable # branch ref by design
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master HEAD 2026-06; action has no release tags — dependabot bumps this pin
+        with:
+          toolchain: stable
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
       - name: Start Redis with authentication
         run: |
@@ -51,8 +53,9 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: dtolnay/rust-toolchain@stable # branch ref by design
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master HEAD 2026-06; action has no release tags — dependabot bumps this pin
         with:
+          toolchain: stable
           components: clippy, rustfmt
       - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
       - run: cargo fmt --check


### PR DESCRIPTION
## Summary

Three small supply-chain hardening items:

- **Pin `dtolnay/rust-toolchain` to a commit SHA** — it was the only mutable action ref across all workflows; a compromised branch would execute arbitrary code in CI. The toolchain is now selected via the `toolchain: stable` input instead of the ref. The action publishes no release tags, so the pin targets master HEAD (annotated), and a new `github-actions` dependabot ecosystem keeps it and all other pinned actions fresh.
- **Remove the stale `RUSTSEC-2025-0134` ignore** from `.cargo/audit.toml` — `rustls-pemfile` is no longer in the dependency tree, and a stale ignore would silently suppress the advisory if the crate ever returned. `cargo audit` passes with the ignore removed.
- **Widen `.dockerignore` to `.env*` with `!.env.example`** — `.env.production` previously entered the Docker build context (relevant with remote/BuildKit builders and cached contexts). Verified the build context now excludes every `.env` variant except the secret-free example file, and that the Dockerfile copies no `.env` files.

## Verification

CI/dependabot YAML and audit.toml parse cleanly; both pinned occurrences verified against the upstream SHA; Docker build context inspected before/after; 66 unit tests pass.
