### PR TITLE
chore: rename datastore env/config and prose from Redis to Valkey

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,9 +2,9 @@
 ADMIN_PUBKEY=
 ADMIN_ALIAS=admin
 
-# Redis (REDIS_PASSWORD is required — docker-compose will fail without it)
-REDIS_PASSWORD=
-REDIS_URL=redis://:<redis password>@redis:6379
+# Valkey (VALKEY_PASSWORD is required — docker-compose will fail without it)
+VALKEY_PASSWORD=
+VALKEY_URL=redis://:<valkey password>@valkey:6379
 
 # Server
 BIND_ADDR=0.0.0.0:3000

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,14 +23,14 @@ jobs:
         with:
           toolchain: stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
-      - name: Start Redis with authentication
+      - name: Start Valkey with authentication
         run: |
-          docker run -d --name redis -p 6379:6379 \
-            redis:7-alpine@sha256:8b81dd37ff027bec4e516d41acfbe9fe2460070dc6d4a4570a2ac5b9d59df065 \
-            redis-server --requirepass ci-test-pass
+          docker run -d --name valkey -p 6379:6379 \
+            valkey/valkey:9.1.0-alpine@sha256:a35428eba9043cc0b79dbe54100f0c92784f2de00ad09b01182bfb1c5c83d1bd \
+            valkey-server --requirepass ci-test-pass
           for i in $(seq 1 30); do
-            if docker exec redis redis-cli -a ci-test-pass ping 2>/dev/null | grep -q PONG; then
-              echo "Redis is ready"
+            if docker exec valkey valkey-cli -a ci-test-pass ping 2>/dev/null | grep -q PONG; then
+              echo "Valkey is ready"
               break
             fi
             sleep 1
@@ -40,11 +40,11 @@ jobs:
       - name: Unit tests
         run: cargo test --locked --lib
         env:
-          REDIS_URL: redis://:ci-test-pass@127.0.0.1:6379
-      - name: Integration tests (sequential, shared Redis)
+          VALKEY_URL: redis://:ci-test-pass@127.0.0.1:6379
+      - name: Integration tests (sequential, shared Valkey)
         run: cargo test --locked --test integration -- --test-threads=1
         env:
-          REDIS_URL: redis://:ci-test-pass@127.0.0.1:6379
+          VALKEY_URL: redis://:ci-test-pass@127.0.0.1:6379
 
   lint:
     name: Lint

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ lto = true
 
 [dev-dependencies]
 reqwest = { version = "0.13.4", features = ["json", "multipart"] }
-testcontainers-modules = { version = "0.15", features = ["redis"] }
+testcontainers-modules = { version = "0.15", features = ["valkey"] }
 tempfile = "3"
 futures = "0.3"
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ cargo run -- keygen <alias> <secret>
 nano .env
 # Set ADMIN_ALIAS=<your alias>
 # Set ADMIN_PUBKEY=<generated public key>
-# Set REDIS_PASSWORD=<strong password>
+# Set VALKEY_PASSWORD=<strong password>
 
 # 4. Start nullpad
 docker compose up -d
@@ -52,16 +52,16 @@ docker compose up -d
 
 ## Development Setup
 
-**Prerequisites**: Rust (latest stable), Redis (7.0+)
+**Prerequisites**: Rust (latest stable), Valkey (7.0+, a Redis-compatible fork)
 
 ```bash
-# Install Redis
-# Ubuntu/Debian: apt install redis-server
-# macOS: brew install redis
-# Or run via Docker: docker run -d -p 6379:6379 redis:7-alpine
+# Install Valkey (or any Redis-compatible server)
+# Ubuntu/Debian: apt install valkey
+# macOS: brew install valkey
+# Or run via Docker: docker run -d -p 6379:6379 valkey/valkey:9.1.0-alpine
 
-# Start Redis (skip if using Docker)
-redis-server
+# Start Valkey (skip if using Docker)
+valkey-server
 
 # Copy config and set ADMIN_PUBKEY
 cp .env.example .env
@@ -81,10 +81,10 @@ See `.env.example` for all available options. Key environment variables:
 
 - `ADMIN_PUBKEY` — Base64-encoded Ed25519 public key (32 bytes), generated via `cargo run -- keygen` (required). **Keep this confidential** — treat it like a password hash. Because the Ed25519 keypair is derived deterministically from `Argon2id(secret, salt=alias)`, anyone who obtains the public key can run an offline dictionary attack against the secret with no rate limiting.
 - `ADMIN_ALIAS` — Admin username (default: "admin")
-- `REDIS_URL` — Redis connection string (default: "redis://127.0.0.1:6379")
+- `VALKEY_URL` — Valkey connection string (default: "redis://127.0.0.1:6379")
 - `BIND_ADDR` — Server bind address (default: "0.0.0.0:3000")
 - `PASTE_STORAGE_PATH` — Directory for encrypted paste content (default: "/data/pastes")
-- `REDIS_PASSWORD` — Redis authentication password (required in Docker)
+- `VALKEY_PASSWORD` — Valkey authentication password (required in Docker)
 - `MAX_UPLOAD_BYTES` — Max file size (default: 52428800 / 50MB)
 - `DEFAULT_TTL_SECS` — Default paste expiration (default: 86400 / 24h)
 - `MAX_TTL_SECS` — Maximum paste lifetime (default: 604800 / 7d)
@@ -131,7 +131,7 @@ Rate limiting, session lifetimes, and challenge timeouts are also configurable. 
 
 **Data Expiration**
 
-- All Redis keys have TTLs — pastes expire based on chosen duration (1 minute to 1 week)
+- All Valkey keys have TTLs — pastes expire based on chosen duration (1 minute to 1 week)
 - Burn-after-reading uses atomic Lua script (no race conditions)
 - Burn and admin delete clean up user_pastes references atomically
 
@@ -148,7 +148,7 @@ Rate limiting, session lifetimes, and challenge timeouts are also configurable. 
 **Backend**
 
 - Rust with Axum 0.8 web framework
-- Redis for metadata and sessions (everything expires)
+- Valkey for metadata and sessions (everything expires)
 - Filesystem for encrypted paste content (low memory footprint)
 - ed25519-dalek for signature verification
 - zeroize for secure memory cleanup
@@ -171,7 +171,7 @@ Rate limiting, session lifetimes, and challenge timeouts are also configurable. 
 
 ### Public
 
-- `GET /healthz` — Health check (returns Redis connectivity status)
+- `GET /healthz` — Health check (returns Valkey connectivity status)
 - `POST /api/paste` — Create encrypted paste
 - `GET /api/paste/{id}` — Retrieve paste (deletes if burn-after-reading)
 - `POST /api/auth/challenge` — Request authentication nonce

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ See `.env.example` for all available options. Key environment variables:
 
 - `ADMIN_PUBKEY` — Base64-encoded Ed25519 public key (32 bytes), generated via `cargo run -- keygen` (required). **Keep this confidential** — treat it like a password hash. Because the Ed25519 keypair is derived deterministically from `Argon2id(secret, salt=alias)`, anyone who obtains the public key can run an offline dictionary attack against the secret with no rate limiting.
 - `ADMIN_ALIAS` — Admin username (default: "admin")
-- `VALKEY_URL` — Valkey connection string (default: "redis://127.0.0.1:6379")
+- `VALKEY_URL` — Valkey connection string (default: "redis://127.0.0.1:6379"). nullpad speaks RESP via the redis-rs client, so any RESP-compatible server works (Valkey or Redis); the URL keeps the `redis://` scheme either way
 - `BIND_ADDR` — Server bind address (default: "0.0.0.0:3000")
 - `PASTE_STORAGE_PATH` — Directory for encrypted paste content (default: "/data/pastes")
 - `VALKEY_PASSWORD` — Valkey authentication password (required in Docker)
@@ -148,7 +148,7 @@ Rate limiting, session lifetimes, and challenge timeouts are also configurable. 
 **Backend**
 
 - Rust with Axum 0.8 web framework
-- Valkey for metadata and sessions (everything expires)
+- Valkey for metadata and sessions (everything expires; any RESP-compatible server works, including Redis)
 - Filesystem for encrypted paste content (low memory footprint)
 - ed25519-dalek for signature verification
 - zeroize for secure memory cleanup

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,7 +35,7 @@ Out of scope:
 - Vulnerabilities in dependencies (report upstream, but let us know)
 - Social engineering
 - Physical attacks
-- Issues in third-party services (Cloudflare, Redis, etc.)
+- Issues in third-party services (Cloudflare, Valkey, etc.)
 
 ## Security Model
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,12 +4,12 @@ services:
     ports:
       - "3015:3000"
     depends_on:
-      redis:
+      valkey:
         condition: service_healthy
     env_file:
       - .env
     environment:
-      - REDIS_URL=redis://:${REDIS_PASSWORD:?REDIS_PASSWORD must be set}@redis:6379
+      - VALKEY_URL=redis://:${VALKEY_PASSWORD:?VALKEY_PASSWORD must be set}@valkey:6379
       - RUST_LOG=info
     restart: unless-stopped
     networks:
@@ -36,12 +36,12 @@ services:
     tmpfs:
       - /tmp
 
-  redis:
-    # To update: docker pull redis:7-alpine && docker inspect --format='{{index .RepoDigests 0}}' redis:7-alpine
-    image: redis:7-alpine@sha256:8b81dd37ff027bec4e516d41acfbe9fe2460070dc6d4a4570a2ac5b9d59df065
-    user: redis
+  valkey:
+    # To update: docker pull valkey/valkey:9.1.0-alpine && docker inspect --format='{{index .RepoDigests 0}}' valkey/valkey:9.1.0-alpine
+    image: valkey/valkey:9.1.0-alpine@sha256:a35428eba9043cc0b79dbe54100f0c92784f2de00ad09b01182bfb1c5c83d1bd
+    user: valkey
     volumes:
-      - redis-data:/data
+      - valkey-data:/data
     env_file:
       - .env
     restart: unless-stopped
@@ -49,18 +49,18 @@ services:
     # file until rewrite. Aggressive rewrite settings below minimize this window.
     # For stronger burn guarantees, disable AOF (--appendonly no --save "").
     command: >-
-      sh -c 'redis-server --appendonly yes
+      sh -c 'valkey-server --appendonly yes
       --auto-aof-rewrite-percentage 50
       --auto-aof-rewrite-min-size 16mb
-      --requirepass "$$REDIS_PASSWORD"
-      --maxmemory "$${REDIS_MAXMEMORY:-2gb}"
+      --requirepass "$$VALKEY_PASSWORD"
+      --maxmemory "$${VALKEY_MAXMEMORY:-2gb}"
       --maxmemory-policy volatile-lru
       --rename-command FLUSHALL ""
       --rename-command FLUSHDB ""
       --rename-command DEBUG ""
       --rename-command CONFIG ""'
     healthcheck:
-      test: ["CMD-SHELL", "redis-cli -a \"$REDIS_PASSWORD\" --no-auth-warning ping"]
+      test: ["CMD-SHELL", "valkey-cli -a \"$VALKEY_PASSWORD\" --no-auth-warning ping"]
       interval: 5s
       timeout: 3s
       retries: 5
@@ -84,5 +84,5 @@ networks:
     driver: bridge
 
 volumes:
-  redis-data:
+  valkey-data:
   paste-data:

--- a/src/auth/middleware.rs
+++ b/src/auth/middleware.rs
@@ -11,12 +11,12 @@ use std::sync::Arc;
 /// Application state shared across handlers.
 #[derive(Clone)]
 pub struct AppState {
-    /// Redis connection manager with automatic reconnection.
+    /// Valkey connection manager with automatic reconnection.
     /// ConnectionManager handles connection failures with exponential backoff retry,
-    /// eliminating the need for manual pod restarts when Redis becomes temporarily unavailable.
+    /// eliminating the need for manual pod restarts when Valkey becomes temporarily unavailable.
     pub redis: redis::aio::ConnectionManager,
     pub config: Arc<Config>,
-    /// Random 32-byte salt for HMAC-SHA256 hashing of client IPs in Redis keys.
+    /// Random 32-byte salt for HMAC-SHA256 hashing of client IPs in Valkey keys.
     pub ip_hmac_salt: Arc<[u8; 32]>,
 }
 
@@ -99,7 +99,7 @@ fn extract_bearer_token(headers: &axum::http::HeaderMap) -> Option<String> {
 ///
 /// Returns Some(AuthSession) if valid Bearer header or `np_session` cookie present,
 /// None if neither source provides credentials.
-/// Propagates system errors (Redis failures) instead of silently degrading.
+/// Propagates system errors (Valkey failures) instead of silently degrading.
 impl FromRequestParts<AppState> for Option<AuthSession> {
     type Rejection = AppError;
 
@@ -158,10 +158,10 @@ pub struct RateLimitResult {
     pub retry_after: Option<u64>,
 }
 
-/// Check rate limit using Redis INCR with TTL.
+/// Check rate limit using Valkey INCR with TTL.
 ///
 /// # Arguments
-/// * `con` - Redis connection
+/// * `con` - Valkey connection
 /// * `key` - Rate limit key (e.g., "ratelimit:ip:127.0.0.1")
 /// * `max` - Maximum requests allowed in window
 /// * `window_secs` - Time window in seconds
@@ -211,15 +211,15 @@ mod tests {
 
     #[tokio::test]
     async fn test_check_rate_limit() {
-        // Note: This test requires a running Redis instance
-        // Skip if REDIS_URL is not set
-        let redis_url =
-            std::env::var("REDIS_URL").unwrap_or_else(|_| "redis://127.0.0.1:6379".to_string());
+        // Note: This test requires a running Valkey instance
+        // Skip if VALKEY_URL is not set
+        let valkey_url =
+            std::env::var("VALKEY_URL").unwrap_or_else(|_| "redis://127.0.0.1:6379".to_string());
 
-        let client = match redis::Client::open(redis_url) {
+        let client = match redis::Client::open(valkey_url) {
             Ok(c) => c,
             Err(_) => {
-                eprintln!("Skipping test: Redis not available");
+                eprintln!("Skipping test: Valkey not available");
                 return;
             }
         };
@@ -227,7 +227,7 @@ mod tests {
         let mut con = match client.get_multiplexed_async_connection().await {
             Ok(c) => c,
             Err(_) => {
-                eprintln!("Skipping test: Redis connection failed");
+                eprintln!("Skipping test: Valkey connection failed");
                 return;
             }
         };

--- a/src/cleanup.rs
+++ b/src/cleanup.rs
@@ -1,8 +1,8 @@
 //! Background cleanup job for orphaned paste files.
 //!
-//! When Redis expires paste metadata (via TTL), the corresponding file
+//! When Valkey expires paste metadata (via TTL), the corresponding file
 //! on disk becomes orphaned. This job periodically scans the storage
-//! directory and deletes files whose metadata no longer exists in Redis.
+//! directory and deletes files whose metadata no longer exists in Valkey.
 
 use crate::util::{is_valid_nanoid, now_secs};
 use redis::AsyncCommands;
@@ -10,7 +10,7 @@ use std::path::Path;
 use std::time::Duration;
 use tokio::fs;
 
-/// Maximum files to process per cleanup cycle to bound Redis load.
+/// Maximum files to process per cleanup cycle to bound Valkey load.
 const CLEANUP_BATCH_SIZE: usize = 50;
 const CLEANUP_MAX_FILES_PER_CYCLE: usize = 1000;
 
@@ -20,7 +20,7 @@ const STALE_TMP_SECS: u64 = 3600;
 /// Run the cleanup loop.
 ///
 /// Scans the paste storage directory every `interval` and deletes
-/// orphaned files (those without corresponding Redis metadata).
+/// orphaned files (those without corresponding Valkey metadata).
 pub async fn run_cleanup_loop<C>(mut redis: C, storage_path: &Path, interval: Duration)
 where
     C: AsyncCommands + Clone + Send + 'static,
@@ -112,7 +112,7 @@ where
                 None => continue,
             };
 
-            // Validate paste ID before using in Redis key
+            // Validate paste ID before using in Valkey key
             if !is_valid_paste_id(&paste_id) {
                 tracing::warn!(
                     filename = %paste_id,
@@ -165,7 +165,7 @@ where
     Ok(())
 }
 
-/// Process a batch of files: pipeline Redis EXISTS queries, then delete orphans.
+/// Process a batch of files: pipeline Valkey EXISTS queries, then delete orphans.
 async fn process_batch<C>(
     redis: &mut C,
     files: &mut Vec<(String, std::path::PathBuf)>,
@@ -176,7 +176,7 @@ where
     let mut checked: u64 = 0;
     let mut deleted: u64 = 0;
 
-    // Build Redis pipeline for batched EXISTS queries
+    // Build Valkey pipeline for batched EXISTS queries
     let mut pipe = redis::pipe();
     for (paste_id, _) in files.iter() {
         let redis_key = format!("paste:{}", paste_id);
@@ -186,7 +186,7 @@ where
     let results: Vec<bool> = match pipe.query_async(redis).await {
         Ok(r) => r,
         Err(e) => {
-            tracing::warn!(error = %e, batch_size = files.len(), "Cleanup: Redis pipeline failed, skipping batch");
+            tracing::warn!(error = %e, batch_size = files.len(), "Cleanup: Valkey pipeline failed, skipping batch");
             files.clear();
             return Ok((0, 0));
         }
@@ -219,6 +219,6 @@ pub enum CleanupError {
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
 
-    #[error("Redis error: {0}")]
+    #[error("Valkey error: {0}")]
     Redis(#[from] redis::RedisError),
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,8 +8,8 @@ pub struct Config {
     pub admin_pubkey: String,
     pub admin_alias: String,
 
-    // Redis
-    pub redis_url: String,
+    // Valkey
+    pub valkey_url: String,
 
     // Server
     pub bind_addr: SocketAddr,
@@ -50,7 +50,7 @@ impl std::fmt::Debug for Config {
         f.debug_struct("Config")
             .field("admin_pubkey", &"[REDACTED]")
             .field("admin_alias", &self.admin_alias)
-            .field("redis_url", &"[REDACTED]")
+            .field("valkey_url", &"[REDACTED]")
             .field("bind_addr", &self.bind_addr)
             .field("max_upload_bytes", &self.max_upload_bytes)
             .field("default_ttl_secs", &self.default_ttl_secs)
@@ -143,9 +143,9 @@ impl Config {
             ));
         }
 
-        // Redis — required to prevent silent unauthenticated connections
-        let redis_url =
-            env::var("REDIS_URL").map_err(|_| ConfigError::MissingVar("REDIS_URL".to_string()))?;
+        // Valkey — required to prevent silent unauthenticated connections
+        let valkey_url = env::var("VALKEY_URL")
+            .map_err(|_| ConfigError::MissingVar("VALKEY_URL".to_string()))?;
 
         // Server
         let bind_addr_str = env::var("BIND_ADDR").unwrap_or_else(|_| "0.0.0.0:3000".to_string());
@@ -203,7 +203,7 @@ impl Config {
         Ok(Config {
             admin_pubkey,
             admin_alias,
-            redis_url,
+            valkey_url,
             bind_addr,
             max_upload_bytes,
             default_ttl_secs,
@@ -255,7 +255,7 @@ mod tests {
     fn clear_test_env() {
         env::remove_var("ADMIN_PUBKEY");
         env::remove_var("ADMIN_ALIAS");
-        env::remove_var("REDIS_URL");
+        env::remove_var("VALKEY_URL");
         env::remove_var("BIND_ADDR");
         env::remove_var("MAX_UPLOAD_BYTES");
         env::remove_var("DEFAULT_TTL_SECS");
@@ -297,7 +297,7 @@ mod tests {
         clear_test_env();
 
         env::set_var("ADMIN_PUBKEY", TEST_PUBKEY_B64);
-        env::set_var("REDIS_URL", "redis://127.0.0.1:6379");
+        env::set_var("VALKEY_URL", "redis://127.0.0.1:6379");
         env::set_var("BIND_ADDR", "invalid_address");
 
         let result = Config::from_env();
@@ -385,7 +385,7 @@ mod tests {
         clear_test_env();
 
         env::set_var("ADMIN_PUBKEY", TEST_PUBKEY_B64);
-        env::set_var("REDIS_URL", "redis://127.0.0.1:6379");
+        env::set_var("VALKEY_URL", "redis://127.0.0.1:6379");
         env::set_var("ADMIN_ALIAS", "a"); // Only 1 character
 
         let result = Config::from_env();
@@ -404,7 +404,7 @@ mod tests {
         clear_test_env();
 
         env::set_var("ADMIN_PUBKEY", TEST_PUBKEY_B64);
-        env::set_var("REDIS_URL", "redis://127.0.0.1:6379");
+        env::set_var("VALKEY_URL", "redis://127.0.0.1:6379");
         // 65 characters (exceeds 64 max)
         env::set_var("ADMIN_ALIAS", "a".repeat(65));
 
@@ -424,7 +424,7 @@ mod tests {
         clear_test_env();
 
         env::set_var("ADMIN_PUBKEY", TEST_PUBKEY_B64);
-        env::set_var("REDIS_URL", "redis://127.0.0.1:6379");
+        env::set_var("VALKEY_URL", "redis://127.0.0.1:6379");
         env::set_var("ADMIN_ALIAS", "admin@example"); // Contains '@'
 
         let result = Config::from_env();
@@ -443,7 +443,7 @@ mod tests {
         clear_test_env();
 
         env::set_var("ADMIN_PUBKEY", TEST_PUBKEY_B64);
-        env::set_var("REDIS_URL", "redis://127.0.0.1:6379");
+        env::set_var("VALKEY_URL", "redis://127.0.0.1:6379");
         env::set_var("ADMIN_ALIAS", "admin user"); // Contains space
 
         let result = Config::from_env();
@@ -462,7 +462,7 @@ mod tests {
         clear_test_env();
 
         env::set_var("ADMIN_PUBKEY", TEST_PUBKEY_B64);
-        env::set_var("REDIS_URL", "redis://127.0.0.1:6379");
+        env::set_var("VALKEY_URL", "redis://127.0.0.1:6379");
         env::set_var("ADMIN_ALIAS", "admin_user-123");
 
         let config = Config::from_env().unwrap();
@@ -478,7 +478,7 @@ mod tests {
 
         // Test minimum length (2 chars)
         env::set_var("ADMIN_PUBKEY", TEST_PUBKEY_B64);
-        env::set_var("REDIS_URL", "redis://127.0.0.1:6379");
+        env::set_var("VALKEY_URL", "redis://127.0.0.1:6379");
         env::set_var("ADMIN_ALIAS", "ab");
 
         let config = Config::from_env().unwrap();
@@ -501,7 +501,7 @@ mod tests {
         // dotenvy::dotenv() won't override existing env vars, so pre-setting them
         // prevents .env from leaking non-default values into the test.
         env::set_var("ADMIN_PUBKEY", TEST_PUBKEY_B64);
-        env::set_var("REDIS_URL", "redis://127.0.0.1:6379");
+        env::set_var("VALKEY_URL", "redis://127.0.0.1:6379");
         env::set_var("BIND_ADDR", "0.0.0.0:3000");
         env::set_var("RATE_LIMIT_PASTE_PER_MIN", "10");
         env::set_var("RATE_LIMIT_AUTH_PER_MIN", "5");
@@ -514,7 +514,7 @@ mod tests {
 
         assert_eq!(config.admin_pubkey, TEST_PUBKEY_B64);
         assert_eq!(config.admin_alias, "admin");
-        assert_eq!(config.redis_url, "redis://127.0.0.1:6379");
+        assert_eq!(config.valkey_url, "redis://127.0.0.1:6379");
         assert_eq!(config.bind_addr.to_string(), "0.0.0.0:3000");
         assert_eq!(config.max_upload_bytes, 52_428_800);
         assert_eq!(config.default_ttl_secs, 86_400);

--- a/src/error.rs
+++ b/src/error.rs
@@ -85,7 +85,7 @@ impl IntoResponse for AppError {
 // Convenience conversions from common error types
 impl From<redis::RedisError> for AppError {
     fn from(err: redis::RedisError) -> Self {
-        AppError::Internal(format!("Redis error: {}", err))
+        AppError::Internal(format!("Valkey error: {}", err))
     }
 }
 
@@ -115,13 +115,13 @@ mod tests {
     async fn test_internal_hides_details() {
         // CRITICAL: Internal error must NOT leak detailed message to client
         let (status, body) = error_response(AppError::Internal(
-            "Redis connection refused at 10.0.0.5:6379".to_string(),
+            "Valkey connection refused at 10.0.0.5:6379".to_string(),
         ))
         .await;
         assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
         assert_eq!(body["error"], "Internal server error");
         // Must NOT contain the actual error details
-        assert!(!body["error"].as_str().unwrap().contains("Redis"));
+        assert!(!body["error"].as_str().unwrap().contains("Valkey"));
         assert!(!body["error"].as_str().unwrap().contains("10.0.0.5"));
     }
 
@@ -183,7 +183,7 @@ mod tests {
         ));
         let app_err = AppError::from(redis_err);
         match app_err {
-            AppError::Internal(msg) => assert!(msg.contains("Redis error")),
+            AppError::Internal(msg) => assert!(msg.contains("Valkey error")),
             _ => panic!("Expected Internal variant"),
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@
 //!
 //! Bootstraps the server:
 //! 1. Load configuration from environment
-//! 2. Connect to Redis
+//! 2. Connect to Valkey
 //! 3. Upsert admin user
 //! 4. Build router with API routes + static file serving
 //! 5. Apply security headers middleware
@@ -164,18 +164,19 @@ async fn main() {
         .await
         .expect("Failed to initialize paste storage");
 
-    // Connect to Redis with ConnectionManager for automatic reconnection.
+    // Connect to Valkey with ConnectionManager for automatic reconnection.
     // ConnectionManager handles connection failures with exponential backoff retry,
-    // eliminating the need for manual pod restarts when Redis becomes temporarily unavailable.
-    let redis_client = redis::Client::open(config.redis_url.as_str()).expect("Invalid Redis URL");
-    let mut redis_manager = redis_client
+    // eliminating the need for manual pod restarts when Valkey becomes temporarily unavailable.
+    let valkey_client =
+        redis::Client::open(config.valkey_url.as_str()).expect("Invalid Valkey URL");
+    let mut valkey_manager = valkey_client
         .get_connection_manager()
         .await
-        .expect("Failed to connect to Redis");
+        .expect("Failed to connect to Valkey");
 
     // Upsert admin user (permanent, no TTL)
     storage::user::upsert_admin(
-        &mut redis_manager,
+        &mut valkey_manager,
         &config.admin_pubkey,
         &config.admin_alias,
     )
@@ -183,8 +184,8 @@ async fn main() {
     .expect("Failed to upsert admin user");
     tracing::info!("Admin user '{}' configured", config.admin_alias);
 
-    // Clone redis for cleanup job before building state
-    let cleanup_redis = redis_manager.clone();
+    // Clone the Valkey connection for the cleanup job before building state
+    let cleanup_valkey = valkey_manager.clone();
 
     // Load or generate a random HMAC salt for IP hashing in rate-limit keys.
     // Persisted to data/hmac_salt so rate-limit keys survive restarts.
@@ -221,7 +222,7 @@ async fn main() {
 
     // Build shared state
     let state = AppState {
-        redis: redis_manager,
+        redis: valkey_manager,
         config: Arc::new(config.clone()),
         ip_hmac_salt: Arc::new(ip_hmac_salt),
     };
@@ -248,7 +249,7 @@ async fn main() {
     // Start cleanup job for orphaned paste files (runs every 5 minutes)
     let cleanup_path = config.paste_storage_path.clone();
     tokio::spawn(async move {
-        cleanup::run_cleanup_loop(cleanup_redis, &cleanup_path, Duration::from_secs(300)).await;
+        cleanup::run_cleanup_loop(cleanup_valkey, &cleanup_path, Duration::from_secs(300)).await;
     });
     tracing::info!("Cleanup job started (5 minute interval)");
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,7 +1,7 @@
 //! Request and response models for the API.
 //!
 //! All models use serde for serialization/deserialization.
-//! Storage models represent Redis data structures.
+//! Storage models represent Valkey data structures.
 
 use serde::{Deserialize, Serialize};
 
@@ -70,7 +70,7 @@ pub struct GetPasteResponse {
     pub needs_pin: Option<bool>,
 }
 
-/// Paste metadata as stored in Redis.
+/// Paste metadata as stored in Valkey.
 /// Content is stored separately on disk via storage::blob.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StoredPasteMeta {
@@ -98,7 +98,7 @@ pub struct StoredPasteMeta {
 }
 
 /// Full paste data (metadata + content) for API operations.
-/// Used when creating/fetching pastes - combines metadata from Redis with content from disk.
+/// Used when creating/fetching pastes - combines metadata from Valkey with content from disk.
 #[derive(Debug, Clone)]
 pub struct StoredPaste {
     pub meta: StoredPasteMeta,
@@ -175,7 +175,7 @@ pub struct UserInfo {
 // Storage Models
 // ============================================================================
 
-/// User data as stored in Redis.
+/// User data as stored in Valkey.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StoredUser {
     pub id: String,
@@ -185,21 +185,21 @@ pub struct StoredUser {
     pub created_at: u64,
 }
 
-/// Invite data as stored in Redis.
+/// Invite data as stored in Valkey.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StoredInvite {
     pub token: String,
     pub created_at: u64,
 }
 
-/// Challenge data as stored in Redis.
+/// Challenge data as stored in Valkey.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StoredChallenge {
     pub nonce: String, // base64
     pub created_at: u64,
 }
 
-/// Session data as stored in Redis.
+/// Session data as stored in Valkey.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StoredSession {
     pub user_id: String,

--- a/src/routes/auth.rs
+++ b/src/routes/auth.rs
@@ -220,7 +220,7 @@ pub async fn register(
     // Validate invite token format
     super::validate_id(&req.token, "invite token", 16)?;
 
-    // Validate pubkey FIRST (before touching Redis): must be valid base64, 32 bytes, and a valid Ed25519 public key
+    // Validate pubkey FIRST (before touching Valkey): must be valid base64, 32 bytes, and a valid Ed25519 public key
     let pubkey_bytes = general_purpose::STANDARD
         .decode(&req.pubkey)
         .map_err(|_| AppError::BadRequest("Invalid public key: not valid base64".to_string()))?;

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -87,7 +87,7 @@ pub fn validate_id(id: &str, label: &str, expected_len: usize) -> Result<(), App
     Ok(())
 }
 
-/// Hash an IP address with HMAC-SHA256 for use in Redis keys and logs.
+/// Hash an IP address with HMAC-SHA256 for use in Valkey keys and logs.
 pub fn hash_ip(salt: &[u8], ip: &IpAddr) -> String {
     type HmacSha256 = Hmac<Sha256>;
     let mut mac = HmacSha256::new_from_slice(salt).expect("HMAC accepts any key size");
@@ -165,7 +165,7 @@ async fn server_config(State(state): State<AppState>) -> impl IntoResponse {
 
 /// GET /healthz — Health check endpoint for liveness/readiness probes.
 ///
-/// Pings Redis and returns 200 if healthy, 503 if Redis is unreachable.
+/// Pings Valkey and returns 200 if healthy, 503 if Valkey is unreachable.
 async fn healthz(State(state): State<AppState>) -> impl IntoResponse {
     // ConnectionManager handles auto-reconnection; just try to PING
     let mut con = state.redis.clone();
@@ -173,7 +173,7 @@ async fn healthz(State(state): State<AppState>) -> impl IntoResponse {
         Ok(_) => (StatusCode::OK, Json(serde_json::json!({"status": "ok"}))),
         Err(_) => (
             StatusCode::SERVICE_UNAVAILABLE,
-            Json(serde_json::json!({"status": "error", "detail": "redis ping failed"})),
+            Json(serde_json::json!({"status": "error", "detail": "valkey ping failed"})),
         ),
     }
 }
@@ -211,7 +211,7 @@ async fn protected_trusted_js(_session: AuthSession) -> Result<impl IntoResponse
 
 /// GET /admin.html — Admin dashboard (requires valid admin session)
 ///
-/// Validates the `np_session` HttpOnly cookie against Redis — same session
+/// Validates the `np_session` HttpOnly cookie against Valkey — same session
 /// check as Bearer-authenticated API calls.
 async fn protected_admin_html(
     AdminSession(_): AdminSession,

--- a/src/routes/paste.rs
+++ b/src/routes/paste.rs
@@ -163,7 +163,7 @@ pub async fn create_paste(
     }
 
     // Use config default if client omitted ttl_secs.
-    // ttl_secs=0 means "forever" (no expiration) — admin only to prevent Redis memory exhaustion.
+    // ttl_secs=0 means "forever" (no expiration) — admin only to prevent Valkey memory exhaustion.
     let requested_ttl = metadata.ttl_secs.unwrap_or(state.config.default_ttl_secs);
     let ttl_secs = if requested_ttl == 0 {
         match &auth_session {
@@ -211,7 +211,7 @@ pub async fn create_paste(
         encrypted_content,
     };
 
-    // Store paste (metadata to Redis via SETNX, then content to disk)
+    // Store paste (metadata to Valkey via SETNX, then content to disk)
     storage::paste::store_paste(
         &mut con,
         &state.config.paste_storage_path,

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,10 +1,10 @@
 //! Storage layer for pastes, users, sessions, and challenges.
 //!
-//! - Redis: metadata, users, sessions, challenges
+//! - Valkey: metadata, users, sessions, challenges
 //! - Filesystem: paste content (encrypted blobs)
 //!
-//! All functions are async. Redis uses redis::AsyncCommands.
-//! Data is serialized to JSON for storage in Redis.
+//! All functions are async. Valkey uses redis::AsyncCommands.
+//! Data is serialized to JSON for storage in Valkey.
 
 pub mod blob;
 pub mod paste;
@@ -34,9 +34,9 @@ pub(crate) fn json_deserialize_err(e: serde_json::Error) -> RedisError {
 /// Maximum number of keys returned by scan_keys to prevent unbounded memory allocation.
 const SCAN_MAX_KEYS: usize = 10_000;
 
-/// Scan for Redis keys matching a pattern using SCAN (non-blocking).
+/// Scan for Valkey keys matching a pattern using SCAN (non-blocking).
 ///
-/// Unlike KEYS, SCAN does not block the Redis server during iteration.
+/// Unlike KEYS, SCAN does not block the Valkey server during iteration.
 /// Capped at SCAN_MAX_KEYS results to prevent unbounded memory growth.
 pub async fn scan_keys<C>(con: &mut C, pattern: &str) -> Result<Vec<String>, redis::RedisError>
 where

--- a/src/storage/paste.rs
+++ b/src/storage/paste.rs
@@ -1,6 +1,6 @@
 //! Paste storage operations.
 //!
-//! Redis key patterns:
+//! Valkey key patterns:
 //! - `paste:{nanoid}` — paste metadata (JSON, no content)
 //! - `user_pastes:{user_id}` — SET of paste IDs owned by user
 //!
@@ -12,7 +12,7 @@ use crate::storage::blob;
 use redis::AsyncCommands;
 use std::path::Path;
 
-/// Store a paste: claim ID in Redis first (SETNX), then write content to disk.
+/// Store a paste: claim ID in Valkey first (SETNX), then write content to disk.
 ///
 /// Uses SET NX (set-if-not-exists) to atomically claim the paste ID, preventing
 /// overwrites of existing pastes. If the ID already exists, returns an error
@@ -35,7 +35,7 @@ where
 
     // Step 1: Atomically claim the paste ID with SET NX (set-if-not-exists).
     // This prevents overwriting existing pastes when clients control the ID.
-    // Redis SET NX returns "OK" on success or nil when key exists.
+    // Valkey SET NX returns "OK" on success or nil when key exists.
     let mut cmd = redis::cmd("SET");
     cmd.arg(&key).arg(&json);
     if ttl_secs > 0 {
@@ -43,9 +43,9 @@ where
     }
     cmd.arg("NX");
 
-    // Redis SET NX returns "OK" (Some) on success, nil (None) when key exists.
+    // Valkey SET NX returns "OK" (Some) on success, nil (None) when key exists.
     // Using Option<String> correctly maps nil to None without type errors.
-    // Real Redis errors (connection, auth, OOM) propagate via `?`.
+    // Real Valkey errors (connection, auth, OOM) propagate via `?`.
     let result: Option<String> = cmd.query_async(con).await?;
     let claimed = result.is_some();
 
@@ -57,14 +57,14 @@ where
         )));
     }
 
-    // Step 2: Write content to disk (only after Redis confirms the ID is ours).
+    // Step 2: Write content to disk (only after Valkey confirms the ID is ours).
     if let Err(e) = blob::write_blob(storage_path, &paste.meta.id, &paste.encrypted_content).await {
-        // Cleanup: delete Redis key if blob write fails
+        // Cleanup: delete Valkey key if blob write fails
         if let Err(cleanup_err) = con.del::<_, ()>(&key).await {
             tracing::error!(
                 paste_id = %paste.meta.id,
                 error = %cleanup_err,
-                "Failed to clean up Redis key after blob write failure"
+                "Failed to clean up Valkey key after blob write failure"
             );
         }
         return Err(redis::RedisError::from((
@@ -99,7 +99,7 @@ where
     Ok(())
 }
 
-/// Get paste metadata only (Redis GET, no blob read, no burn side effects).
+/// Get paste metadata only (Valkey GET, no blob read, no burn side effects).
 ///
 /// Used by PIN gating probe to check `has_pin` without consuming burn pastes.
 pub async fn get_paste_meta<C>(
@@ -129,7 +129,7 @@ where
 /// deleted after confirming the blob can be read, preventing data loss.
 /// `max_blob_bytes` limits the blob size to prevent OOM.
 ///
-/// NOTE: If Redis AOF persistence is enabled, burn-after-reading metadata may
+/// NOTE: If Valkey AOF persistence is enabled, burn-after-reading metadata may
 /// be retained in the AOF log even after deletion. The Lua DEL command is
 /// recorded in the AOF. On AOF rewrite, the key won't appear (since it's
 /// already deleted), but between rewrites the original SET + DEL are both
@@ -207,7 +207,7 @@ where
     }
 }
 
-/// Delete a paste from Redis and disk, cleaning up the owner's user_pastes SET.
+/// Delete a paste from Valkey and disk, cleaning up the owner's user_pastes SET.
 ///
 /// Uses a Lua script to atomically fetch the metadata (for owner_id), delete it,
 /// and SREM from the owner's user_pastes SET. Then deletes the blob from disk.
@@ -326,9 +326,9 @@ where
     Ok(())
 }
 
-/// Delete all pastes owned by a user (Redis metadata + disk blobs).
+/// Delete all pastes owned by a user (Valkey metadata + disk blobs).
 ///
-/// First fetches paste IDs, then deletes Redis metadata via Lua script,
+/// First fetches paste IDs, then deletes Valkey metadata via Lua script,
 /// then deletes blobs from disk. Blob deletion failures are logged but
 /// don't fail the operation (orphaned blobs are cleaned up by cleanup job).
 pub async fn delete_user_pastes<C>(
@@ -350,7 +350,7 @@ where
         return Ok(());
     }
 
-    // Delete Redis metadata via Lua script
+    // Delete Valkey metadata via Lua script
     let script = redis::Script::new(
         r#"
         local user_pastes_key = KEYS[1]

--- a/src/storage/session.rs
+++ b/src/storage/session.rs
@@ -1,6 +1,6 @@
-//! Session and challenge Redis operations.
+//! Session and challenge Valkey operations.
 //!
-//! Redis key patterns:
+//! Valkey key patterns:
 //! - `session:{token}` — session data (JSON)
 //! - `challenge:{alias}` — challenge nonce (JSON)
 //!
@@ -11,7 +11,7 @@
 //! - Challenge nonces are zeroized after verification
 //! - Session tokens are zeroized after consumption
 //!
-//! **Limitations**: Redis stores data in its own memory space, so zeroize only protects
+//! **Limitations**: Valkey stores data in its own memory space, so zeroize only protects
 //! the Rust application's memory. This is defense-in-depth for the application layer.
 //! Additionally, since we're working with String types that come from JSON deserialization,
 //! intermediate copies may exist. We zeroize what we can control directly.
@@ -99,7 +99,7 @@ where
     }
 }
 
-/// Store a session in Redis with TTL (default 15min).
+/// Store a session in Valkey with TTL (default 15min).
 ///
 /// Also adds the session token to the user's session tracking set
 /// (`user_sessions:{user_id}`) for efficient cleanup on user revocation.
@@ -251,7 +251,7 @@ where
     }
 }
 
-/// Delete a session from Redis.
+/// Delete a session from Valkey.
 ///
 /// Also removes the token from the user's session tracking set.
 /// Returns true if the session was deleted, false if it didn't exist.

--- a/src/storage/user.rs
+++ b/src/storage/user.rs
@@ -1,6 +1,6 @@
-//! User and invite Redis operations.
+//! User and invite Valkey operations.
 //!
-//! Redis key patterns:
+//! Valkey key patterns:
 //! - `user:{nanoid}` — individual user data (JSON)
 //! - `alias:{alias}` — alias lookup to user_id (STRING)
 //! - `invite:{token}` — invite data (JSON)
@@ -153,7 +153,7 @@ where
     Ok(())
 }
 
-/// List all users in Redis.
+/// List all users in Valkey.
 ///
 /// Scans for keys matching `user:*` and deserializes each.
 /// User JSON data is zeroized after deserialization.
@@ -266,7 +266,7 @@ where
     }
 }
 
-/// Store an invite in Redis with TTL.
+/// Store an invite in Valkey with TTL.
 pub async fn store_invite<C>(
     con: &mut C,
     invite: &StoredInvite,
@@ -282,7 +282,7 @@ where
     Ok(())
 }
 
-/// Delete an invite from Redis.
+/// Delete an invite from Valkey.
 ///
 /// Returns true if the invite was deleted, false if it didn't exist.
 pub async fn delete_invite<C>(con: &mut C, token: &str) -> Result<bool, redis::RedisError>
@@ -294,7 +294,7 @@ where
     Ok(deleted > 0)
 }
 
-/// List all invites in Redis.
+/// List all invites in Valkey.
 ///
 /// Scans for keys matching `invite:*` and deserializes each.
 /// Invite JSON data is zeroized after deserialization.

--- a/static/info.html
+++ b/static/info.html
@@ -76,7 +76,7 @@
       </div>
       <div class="panel-body">
         <p class="text-muted">
-          Paste metadata, sessions, and user records are stored in Redis with time-to-live (TTL) values. Encrypted paste content is stored separately on disk. Pastes automatically expire based on your chosen duration (1 minute to 1 week). Burn-after-reading pastes use an atomic read-and-delete operation to ensure they're destroyed after a single view.
+          Paste metadata, sessions, and user records are stored in Valkey with time-to-live (TTL) values. Encrypted paste content is stored separately on disk. Pastes automatically expire based on your chosen duration (1 minute to 1 week). Burn-after-reading pastes use an atomic read-and-delete operation to ensure they're destroyed after a single view.
         </p>
       </div>
     </div>

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,9 +1,9 @@
 //! Integration tests for nullpad API.
 //!
-//! Tests use testcontainers to spin up a throwaway Redis instance automatically.
-//! Only a running Docker daemon is required — no external Redis needed.
+//! Tests use testcontainers to spin up a throwaway Valkey-compatible instance automatically.
+//! Only a running Docker daemon is required — no external Valkey needed.
 //!
-//! Uses a custom harness (`harness = false`) so that the Redis container is owned
+//! Uses a custom harness (`harness = false`) so that the Valkey container is owned
 //! by `main()` and explicitly removed after all tests complete. This prevents
 //! container leaks — `static` containers never drop, so previous versions leaked
 //! one Docker container per test process.
@@ -24,13 +24,13 @@ use testcontainers_modules::testcontainers::runners::AsyncRunner;
 use testcontainers_modules::testcontainers::ImageExt;
 use tower_http::services::ServeDir;
 
-/// Redis URL set once in `main()`, read by all test helpers.
-static REDIS_URL: OnceLock<String> = OnceLock::new();
+/// Valkey URL set once in `main()`, read by all test helpers.
+static VALKEY_URL: OnceLock<String> = OnceLock::new();
 
-fn get_redis_url() -> &'static str {
-    REDIS_URL
+fn get_valkey_url() -> &'static str {
+    VALKEY_URL
         .get()
-        .expect("REDIS_URL not initialized — tests must run via main()")
+        .expect("VALKEY_URL not initialized — tests must run via main()")
 }
 
 /// Run a named async test function, printing pass/fail like the default harness.
@@ -71,17 +71,17 @@ macro_rules! run_tests {
 
 #[tokio::main]
 async fn main() {
-    // Start Redis container — owned by main(), removed at end.
+    // Start Valkey-compatible Redis testcontainer — owned by main(), removed at end.
     let container = Redis::default()
         .with_tag("7-alpine")
         .start()
         .await
-        .expect("Failed to start Redis container");
+        .expect("Failed to start Valkey container");
     let host = container.get_host().await.unwrap();
     let port = container.get_host_port_ipv4(6379).await.unwrap();
-    REDIS_URL
+    VALKEY_URL
         .set(format!("redis://{}:{}", host, port))
-        .expect("REDIS_URL already set");
+        .expect("VALKEY_URL already set");
 
     let (passed, failed) = run_tests![
         test_create_and_get_paste,
@@ -136,7 +136,7 @@ async fn main() {
     container
         .rm()
         .await
-        .expect("Failed to remove Redis container");
+        .expect("Failed to remove Valkey container");
 
     println!(
         "\ntest result: {}. {} passed; {} failed\n",
@@ -203,13 +203,14 @@ async fn spawn_test_server_configured(
     let (admin_key, admin_pubkey) = test_keypair();
     let admin_alias = format!("testadmin_{}", nanoid::nanoid!(6));
 
-    let test_redis_url = get_redis_url().to_string();
-    let redis_client = redis::Client::open(test_redis_url.as_str()).expect("Failed to open Redis");
-    let redis_manager = redis_client
+    let test_valkey_url = get_valkey_url().to_string();
+    let valkey_client =
+        redis::Client::open(test_valkey_url.as_str()).expect("Failed to open Valkey");
+    let valkey_manager = valkey_client
         .get_connection_manager()
         .await
         .expect("Failed to get connection manager");
-    let mut con = redis_manager.clone();
+    let mut con = valkey_manager.clone();
 
     nullpad::storage::user::upsert_admin(&mut con, &admin_pubkey, &admin_alias)
         .await
@@ -224,7 +225,7 @@ async fn spawn_test_server_configured(
     let config = Config {
         admin_pubkey,
         admin_alias: admin_alias.clone(),
-        redis_url: test_redis_url.clone(),
+        valkey_url: test_valkey_url.clone(),
         bind_addr: "127.0.0.1:0".parse().unwrap(),
         max_upload_bytes: 52_428_800,
         default_ttl_secs: 86400,
@@ -245,7 +246,7 @@ async fn spawn_test_server_configured(
     };
 
     let state = AppState {
-        redis: redis_manager,
+        redis: valkey_manager,
         config: Arc::new(config),
         ip_hmac_salt: Arc::new(rand::random()),
     };

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,6 +1,6 @@
 //! Integration tests for nullpad API.
 //!
-//! Tests use testcontainers to spin up a throwaway Valkey-compatible instance automatically.
+//! Tests use testcontainers to spin up a throwaway Valkey instance automatically.
 //! Only a running Docker daemon is required — no external Valkey needed.
 //!
 //! Uses a custom harness (`harness = false`) so that the Valkey container is owned
@@ -19,9 +19,9 @@ use nullpad::{
 use reqwest::multipart;
 use sha2::Sha256;
 use std::sync::{Arc, OnceLock};
-use testcontainers_modules::redis::Redis;
 use testcontainers_modules::testcontainers::runners::AsyncRunner;
 use testcontainers_modules::testcontainers::ImageExt;
+use testcontainers_modules::valkey::Valkey;
 use tower_http::services::ServeDir;
 
 /// Valkey URL set once in `main()`, read by all test helpers.
@@ -71,9 +71,10 @@ macro_rules! run_tests {
 
 #[tokio::main]
 async fn main() {
-    // Start Valkey-compatible Redis testcontainer — owned by main(), removed at end.
-    let container = Redis::default()
-        .with_tag("7-alpine")
+    // Start a throwaway Valkey testcontainer — owned by main(), removed at end.
+    // Pinned to the tag deployed in CI and the cluster.
+    let container = Valkey::default()
+        .with_tag("9.1.0-alpine")
         .start()
         .await
         .expect("Failed to start Valkey container");


### PR DESCRIPTION
## Summary

Renames the nullpad application's datastore configuration and prose from **Redis** to **Valkey** (a wire-compatible fork), and points the test suite at Valkey. The Rust `redis` **client** crate and the RESP `redis://` URL scheme are unchanged — Valkey speaks both natively.

## Changes

- **Config / env**: `REDIS_URL` → `VALKEY_URL`, `REDIS_PASSWORD` → `VALKEY_PASSWORD`; `Config.redis_url` → `valkey_url`; local connection vars → `valkey_*`. Missing `VALKEY_URL` still fails loudly at startup (no silent default).
- **Tests**: the integration suite now spins up a real `valkey/valkey:9.1.0-alpine` container via the native testcontainers `valkey` module (was `redis:7-alpine`).
- **Docs/prose**: comments, docstrings, README, SECURITY.md, info.html updated to say Valkey.

### Kept intentionally (RESP/library tokens, not the datastore name)
The `redis` Rust **client** crate (`redis::`, `RedisError`), the embedded Lua `redis.call(...)` API (Valkey keeps the `redis` Lua namespace), the `redis://` URL scheme, and the internal `AppState.redis` struct field.

## Verification

- `cargo fmt --check` ✓
- `cargo clippy --all-targets -- -D warnings` ✓
- `cargo test --lib` — 69 passed ✓
- `cargo test --test integration -- --test-threads=1` — 46 passed against Valkey ✓
- `bash tools/verify-vendor.sh` ✓
- `docker build` ✓