### PR TITLE
chore(deps): bump quinn-proto to 0.11.15 (RUSTSEC-2026-0185)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1931,9 +1931,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",


### PR DESCRIPTION
## What

Bumps the transitive dependency `quinn-proto` from 0.11.14 to 0.11.15 (lockfile only).

## Why

RUSTSEC-2026-0185 (GHSA-4w2j-m93h-cj5j) — a remote memory-exhaustion DoS in quinn-proto's unbounded out-of-order stream reassembly — was published 2026-06-22, after `Cargo.lock` was last regenerated. The `cargo audit` step in the **Security Audit** CI job now flags it, failing the check on every open PR (e.g. #93, #94) even though their changes are unrelated. The fix landed in quinn-proto 0.11.15.

`quinn-proto` reaches the lockfile transitively via `reqwest`; it is not in the compiled build graph for our enabled features (`cargo tree -i quinn-proto` is empty), but `cargo audit` scans `Cargo.lock` regardless, so the lockfile must be updated.

## Verification

- `cargo audit` → 0 vulnerabilities (was 1)
- `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test --lib` (69 passed), `cargo build` — all pass
- `docker build` — succeeds

Once merged, rebasing the open dependabot PRs will clear their Security Audit failures.