### PR TITLE
chore(docker): refresh base image digests for libgnutls30 deb12u7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # Stage 1: Build
 # Pin base images by digest for reproducible builds.
 # To update: docker pull rust:slim-bookworm && docker inspect --format='{{index .RepoDigests 0}}' rust:slim-bookworm
-FROM rust:slim-bookworm@sha256:5b9332190bb3b9ece73b810cd1f1e9f06343b294ce184bcb067f0747d7d333ea AS builder
+FROM rust:slim-bookworm@sha256:e18a79fc84dfcfc3ab5ba72290398a644c135c97eaa881447fddc354ee4701a3 AS builder
 
 WORKDIR /build
 
@@ -21,7 +21,7 @@ RUN cargo build --release --locked
 
 # Stage 2: Runtime
 # To update: docker pull debian:bookworm-slim && docker inspect --format='{{index .RepoDigests 0}}' debian:bookworm-slim
-FROM debian:bookworm-slim@sha256:74d56e3931e0d5a1dd51f8c8a2466d21de84a271cd3b5a733b803aa91abf4421
+FROM debian:bookworm-slim@sha256:60eac759739651111db372c07be67863818726f754804b8707c90979bda511df
 
 # Install runtime dependencies and apply security updates
 # curl is needed for Docker healthcheck (hits /healthz)


### PR DESCRIPTION
## What

Bumps the two pinned base-image digests in `Dockerfile`:

- `rust:slim-bookworm` (builder stage)
- `debian:bookworm-slim` (runtime stage)

to the current bookworm releases.

## Why

Trivy flagged two CRITICAL advisories against the runtime image, both in `libgnutls30 3.7.9-2+deb12u6`:

- **CVE-2026-33845**
- **CVE-2026-42010**

Both are fixed in `3.7.9-2+deb12u7`. The runtime stage already runs `apt-get update && apt-get upgrade -y`, but the pinned base digest kept the build cache serving the pre-patch apt layer. Refreshing the pinned digests busts that cache so the upgrade re-resolves `libgnutls30` to the patched version.

## Verification

Built the image and confirmed the patched package is present:

```
libgnutls30 3.7.9-2+deb12u7
```

The remaining `perl-base` and `zlib1g` CRITICALs have no upstream fix in bookworm and are unaffected by this change (and are not linked by the application).

Both new digests were verified as official `docker.io/library` multi-arch OCI indexes covering the deploy target. Change is digest-only; no application code, JS, or HTML touched.