### PR TITLE
ci: align codeql-action pins and group dependabot bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,15 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      # init/analyze are separate deps to dependabot, but the action rejects
+      # mixed versions in one workflow run — bump them together
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"
+      # groups only apply to version-updates by default; without this second
+      # group a security update could still split the versions
+      codeql-action-security:
+        applies-to: security-updates
+        patterns:
+          - "github/codeql-action*"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,17 +31,13 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
 
-      - name: Autobuild
-        if: matrix.build-mode == 'autobuild'
-        uses: github/codeql-action/autobuild@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
-
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           category: /language:${{ matrix.language }}
 


### PR DESCRIPTION
## Problem

Dependabot treats `github/codeql-action/init` and `/analyze` as separate dependencies, so the 4.36.2 → 4.36.3 bump arrived as separate PRs (#98, #99). Each of those PRs runs mixed CodeQL action versions in one workflow, which the action rejects:

```
Loaded a configuration file for version '4.36.2', but running version '4.36.3'
```

Both PRs fail their CodeQL checks and can never merge. Meanwhile #101 (autobuild-only bump) merged green because the Autobuild step never actually runs — leaving main itself with mixed pins.

## Changes

- Bump `codeql-action/init` and `/analyze` to v4.36.3 (`54f647b`) so all pins agree. SHA verified against the `v4.36.3` annotated tag via the GitHub API.
- Add dependabot `groups` for `github/codeql-action*` so future bumps of init/analyze land as a single PR — one group for version updates, one for security updates (a group can only apply to one update type).
- Remove the dead Autobuild step: its `if: matrix.build-mode == 'autobuild'` can never be true since all three languages use `build-mode: none` (the only mode CodeQL supports for rust and interpreted languages). This is why the autobuild pin could drift silently.

## Verification

- `v4.36.3` tag dereferences to `54f647b7e1bb85c95cddabcd46b0c578ec92bc1a` (GitHub API)
- dependabot.yml validates against the official v2 schema; groups pattern matches all subpath dependency names
- cargo fmt/clippy/test and Docker build pass (no Rust/JS touched)

Supersedes #98 and #99.