### PR TITLE
chore(deps): bump cmov to 0.5.4 (GHSA-3rjw-m598-pq24)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,9 +410,9 @@ dependencies = [
 
 [[package]]
 name = "cmov"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "combine"


### PR DESCRIPTION
Fixes dependabot alert #12: Cmov/CmovEq on aarch64 can produce wrong results if high bits of registers are set (moderate, CVE-2026-50185, patched in 0.5.4).

## Details

- Transitive dependency: `cmov` ← `ctutils` ← `digest` ← `hmac`/`sha2`. Not pinned anywhere; lockfile-only patch bump via `cargo update -p cmov`.
- The vulnerable `CmovEq` path is not currently reachable in nullpad: the server's HMAC use (`hash_ip`) never calls `Mac::verify*`, and PIN verification compares via `subtle::ct_eq` (zero-dep crate). The bump removes a latent hazard for aarch64 deployments rather than fixing an active defect.
- Upstream fix inspected: aarch64 backend now masks the condition byte (`tst` + `csel`), remains branch-free, so constant-time properties are preserved.

## Verification

- Checksum in Cargo.lock matches crates.io for cmov 0.5.4 (not yanked); 0.5.4 is the first patched version per the advisory
- cargo fmt/clippy pass, 69 unit + 46 integration tests pass, Docker build passes